### PR TITLE
Fix bundle version stamping via CURRENT_PROJECT_VERSION

### DIFF
--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -10,6 +10,37 @@ env:
   WORKSPACE_NAME: FitWithFriends.xcworkspace
 
 jobs:
+  ios-archive:
+    name: iOS archive (validates deploy pipeline)
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Archive
+        working-directory: ${{ env.XCODE_PROJECT_DIR }}
+        run: |
+          xcodebuild archive \
+            -workspace "$WORKSPACE_NAME" \
+            -scheme FitWithFriends \
+            -configuration Release \
+            -destination "generic/platform=iOS" \
+            -archivePath "$RUNNER_TEMP/FitWithFriends-pr.xcarchive" \
+            CODE_SIGNING_ALLOWED=NO \
+            CURRENT_PROJECT_VERSION="$(date +'%Y%m%d.%H%M')"
+
+      - name: Verify CFBundleVersion was stamped
+        run: |
+          version=$(plutil -extract CFBundleVersion raw \
+            "$RUNNER_TEMP/FitWithFriends-pr.xcarchive/Products/Applications/Fit with Friends.app/Info.plist")
+          echo "CFBundleVersion: $version"
+          # Expect YYYYMMDD.HHMM format
+          if ! echo "$version" | grep -qE '^[0-9]{8}\.[0-9]{4}$'; then
+            echo "error: CFBundleVersion '$version' does not match expected YYYYMMDD.HHMM format"
+            exit 1
+          fi
+
   ios-tests:
     name: iOS build and test
     runs-on: macos-26

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -87,7 +87,8 @@ jobs:
             -authenticationKeyID "$AUTH_KEY_ID" \
             -authenticationKeyIssuerID "$AUTH_KEY_ISSUER_ID" \
             -allowProvisioningUpdates \
-            DEVELOPMENT_TEAM="$TEAM_ID"
+            DEVELOPMENT_TEAM="$TEAM_ID" \
+            CURRENT_PROJECT_VERSION="$(date +'%Y%m%d.%H%M')"
 
       - name: Export and upload to App Store Connect
         env:

--- a/Clients/iOS/FitWithFriends/FitWithFriends.xcodeproj/project.pbxproj
+++ b/Clients/iOS/FitWithFriends/FitWithFriends.xcodeproj/project.pbxproj
@@ -1565,9 +1565,9 @@
 			name = "Set Bundle Version";
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "# Only set version for non-Debug builds (Release, App Store, etc.)\nif [ \"$CONFIGURATION\" != \"Debug\" ]; then\n    # Skip the undefined_arch preprocessing pass used during archive — no real product exists yet\n    if [ \"$ARCHS\" = \"undefined_arch\" ]; then\n        exit 0\n    fi\n    BUILD_VERSION=$(date +\"%Y%m%d.%H%M\")\n    # Use BUILT_PRODUCTS_DIR (not TARGET_BUILD_DIR or CODESIGNING_FOLDER_PATH).\n    # During archive, TARGET_BUILD_DIR and CODESIGNING_FOLDER_PATH both resolve to\n    # InstallationBuildProductsLocation (post-install path), which doesn't exist yet\n    # when this script runs. BUILT_PRODUCTS_DIR always points to where the build system\n    # just placed the compiled app (BuildProductsPath/Release-iphoneos), which exists.\n    PLIST_PATH=\"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Info.plist\"\n    if [ ! -f \"$PLIST_PATH\" ]; then\n        echo \"error: Info.plist not found at $PLIST_PATH — cannot set bundle version\"\n        exit 1\n    fi\n    /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $BUILD_VERSION\" \"$PLIST_PATH\"\nfi\n";
+			shellScript = "# Runs only during deployment post-processing (i.e. xcodebuild archive).\n# At this point the app has been fully assembled and installed to CODESIGNING_FOLDER_PATH,\n# so Info.plist is guaranteed to exist there.\nBUILD_VERSION=$(date +\"%Y%m%d.%H%M\")\nPLIST_PATH=\"${CODESIGNING_FOLDER_PATH}/Info.plist\"\nif [ ! -f \"$PLIST_PATH\" ]; then\n    echo \"error: Info.plist not found at $PLIST_PATH — cannot set bundle version\"\n    exit 1\nfi\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $BUILD_VERSION\" \"$PLIST_PATH\"\n";
 		};
 		0BCF64992BCCB4F4004E98C7 /* Configure Settings bundle for build type */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Clients/iOS/FitWithFriends/FitWithFriends.xcodeproj/project.pbxproj
+++ b/Clients/iOS/FitWithFriends/FitWithFriends.xcodeproj/project.pbxproj
@@ -1349,7 +1349,6 @@
 				0B99FBC7256A016900673133 /* Frameworks */,
 				0B99FBC8256A016900673133 /* Resources */,
 				0BCF64992BCCB4F4004E98C7 /* Configure Settings bundle for build type */,
-				0B2ACCFF2EC04000004966FF /* Set Bundle Version */,
 				80E8D132E8B9DCA561349B7D /* Embed Watch Content */,
 			);
 			buildRules = (
@@ -1555,20 +1554,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0B2ACCFF2EC04000004966FF /* Set Bundle Version */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Set Bundle Version";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-			shellPath = /bin/sh;
-			shellScript = "# Runs only during deployment post-processing (i.e. xcodebuild archive).\n# At this point the app has been fully assembled and installed to CODESIGNING_FOLDER_PATH,\n# so Info.plist is guaranteed to exist there.\nBUILD_VERSION=$(date +\"%Y%m%d.%H%M\")\nPLIST_PATH=\"${CODESIGNING_FOLDER_PATH}/Info.plist\"\nif [ ! -f \"$PLIST_PATH\" ]; then\n    echo \"error: Info.plist not found at $PLIST_PATH — cannot set bundle version\"\n    exit 1\nfi\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $BUILD_VERSION\" \"$PLIST_PATH\"\n";
-		};
 		0BCF64992BCCB4F4004E98C7 /* Configure Settings bundle for build type */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Info-Release.plist
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Info-Release.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.0.2</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIDeviceFamily</key>


### PR DESCRIPTION
## What was wrong

PRs #92, #93, and the first commit of this PR all tried to fix a run script that modifies \`Info.plist\` during archive. All failed because Xcode's new build system runs \`ProcessInfoPlistFile\` (which creates \`Info.plist\` in the archive) concurrently with run script phases — there is no reliable way for a run script to read \`Info.plist\` after it's been written, regardless of which path variable or build phase flag is used.

Specifically:
- \`CODESIGNING_FOLDER_PATH\` / \`TARGET_BUILD_DIR\` — point to the post-install path before the file exists
- \`BUILT_PRODUCTS_DIR\` — correct directory, but \`Info.plist\` isn't placed there at all during archive (it goes directly to \`InstallationBuildProductsLocation\`)
- \`runOnlyForDeploymentPostprocessing = 1\` — runs during the right phase, but still before \`ProcessInfoPlistFile\`
- Input/output file dependencies — create a dependency cycle with the Watch app embed

All of this was diagnosed by running \`xcodebuild archive\` locally with a diagnostic script that dumps all relevant env vars and does \`ls\` on the bundle at script run time.

## Fix

Use Apple's canonical CI build number approach:

1. **\`Info-Release.plist\`**: Change \`CFBundleVersion\` from \`1.0.2\` to \`\$(CURRENT_PROJECT_VERSION)\` — Xcode expands build settings during \`ProcessInfoPlistFile\`, so no run script needed.
2. **\`ios-deploy.yml\`**: Pass \`CURRENT_PROJECT_VERSION=\"\$(date +'%Y%m%d.%H%M')\"\` to \`xcodebuild archive\`.
3. **\`project.pbxproj\`**: Remove the "Set Bundle Version" run script phase entirely.

## Validation

Tested locally with \`xcodebuild archive CODE_SIGNING_ALLOWED=NO CURRENT_PROJECT_VERSION=...\`:

\`\`\`
** ARCHIVE SUCCEEDED **
CFBundleVersion => "20260506.0749"
\`\`\`

## Test plan
- [x] Local archive succeeds with correct CFBundleVersion in the built app
- [ ] App Store Upload workflow succeeds on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)