### PR TITLE
Normalize APNS PEM newlines fetched from Key Vault

### DIFF
--- a/WebService/FitWithFriends/utilities/apnsHelper.ts
+++ b/WebService/FitWithFriends/utilities/apnsHelper.ts
@@ -123,7 +123,9 @@ async function getAPNSToken(): Promise<string> {
         throw new Error('APNS secret value is empty in Key Vault');
     }
 
-    const token = jwt.sign({ iss: teamId, iat: nowSeconds }, secret.value, {
+    // Key Vault may store the PEM with literal \n sequences instead of real newlines.
+    const privateKey = secret.value.replace(/\\n/g, '\n');
+    const token = jwt.sign({ iss: teamId, iat: nowSeconds }, privateKey, {
         algorithm: 'ES256',
         keyid: apnsKeyId,
         noTimestamp: true,


### PR DESCRIPTION
## Summary

- Key Vault may return the APNS private key with literal \`\n\` escape sequences instead of real newlines
- \`jsonwebtoken\` requires a properly formatted PEM when using ES256; without this it throws \`secretOrPrivateKey must be an asymmetric key\`
- Normalize any literal \`\n\` to real newlines before passing the secret to \`jwt.sign\`

## Test plan

- [ ] Verify CI passes
- [ ] Confirm push notifications send successfully after deployment

🤖 Generated with [Claude Code](https://claude.ai/claude-code)