### PR TITLE
Add Restore Purchases to sync subscription state with backend

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Subscriptions/SubscriptionManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Subscriptions/SubscriptionManager.swift
@@ -66,7 +66,32 @@ public class SubscriptionManager: ISubscriptionManager, ObservableObject {
 
     func restorePurchases() async throws {
         try await AppStore.sync()
-        await checkSubscriptionStatus()
+
+        for await entitlement in Transaction.currentEntitlements {
+            let jwsRepresentation = entitlement.jwsRepresentation
+            guard case .verified(let transaction) = entitlement,
+                  transaction.productID == Self.proMonthlyProductId else {
+                continue
+            }
+
+            if let expirationDate = transaction.expirationDate, expirationDate < Date() {
+                Logger.traceInfo(message: "Restore: skipping expired Pro entitlement")
+                continue
+            }
+
+            Logger.traceInfo(message: "Restore: found valid Pro entitlement, syncing with server")
+            let status = try await subscriptionService.validateTransaction(signedTransaction: jwsRepresentation)
+            Logger.traceInfo(message: "Restore: server sync complete, isPro: \(status.isPro)")
+            await MainActor.run {
+                isUserPro = status.isPro
+            }
+            return
+        }
+
+        Logger.traceInfo(message: "Restore: no valid Pro entitlement found")
+        await MainActor.run {
+            isUserPro = false
+        }
     }
 
     func checkSubscriptionStatus() async {

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/About/SettingsView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/About/SettingsView.swift
@@ -10,10 +10,14 @@ import SwiftUI
 struct SettingsView: View {
     let emailUtility: IEmailUtility
     let serverEnvironmentManager: IServerEnvironmentManager
+    let subscriptionManager: ISubscriptionManager
     let onDeleteAccount: () async -> Bool
 
     @State private var showDeleteAccountAlert = false
     @State private var showDeleteAccountErrorAlert = false
+    @State private var isRestoringPurchases = false
+    @State private var showRestoreSuccessAlert = false
+    @State private var showRestoreErrorAlert = false
 
     var body: some View {
         NavigationView {
@@ -43,6 +47,33 @@ struct SettingsView: View {
                     } label: {
                         Label("Activity data troubleshooting", systemImage: "heart.text.square")
                     }
+                }
+
+                Section("Subscription") {
+                    Button {
+                        Task {
+                            isRestoringPurchases = true
+                            defer { isRestoringPurchases = false }
+                            do {
+                                try await subscriptionManager.restorePurchases()
+                                showRestoreSuccessAlert = true
+                            } catch {
+                                showRestoreErrorAlert = true
+                            }
+                        }
+                    } label: {
+                        if isRestoringPurchases {
+                            HStack {
+                                Text("Restore Purchases")
+                                Spacer()
+                                ProgressView()
+                            }
+                        } else {
+                            Label("Restore Purchases", systemImage: "arrow.clockwise")
+                        }
+                    }
+                    .disabled(isRestoringPurchases)
+                    .accessibilityIdentifier("RestorePurchasesButton")
                 }
 
                 Section("More") {
@@ -87,6 +118,16 @@ struct SettingsView: View {
         } message: {
             Text("Failed to delete your account. Please try again later.")
         }
+        .alert("Purchases Restored", isPresented: $showRestoreSuccessAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Your subscription has been restored.")
+        }
+        .alert("Restore Failed", isPresented: $showRestoreErrorAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Failed to restore purchases. Please try again.")
+        }
     }
 }
 
@@ -94,6 +135,7 @@ struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
         SettingsView(emailUtility: MockEmailUtility(),
                      serverEnvironmentManager: ServerEnvironmentManager(userDefaults: UserDefaults.standard),
+                     subscriptionManager: MockSubscriptionManager(),
                      onDeleteAccount: { return true })
     }
 }

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Home/LoggedInContentView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Home/LoggedInContentView.swift
@@ -182,6 +182,7 @@ struct LoggedInContentView: View {
                     case .settings:
                         SettingsView(emailUtility: objectGraph.emailUtility,
                                      serverEnvironmentManager: objectGraph.serverEnvironmentManager,
+                                     subscriptionManager: objectGraph.subscriptionManager,
                                      onDeleteAccount: { return await homepageViewModel.deleteAccount() })
                     case .proUpgrade:
                         ProUpgradeView(homepageSheetViewModel: homepageSheetViewModel,

--- a/Clients/iOS/FitWithFriends/UITests/AboutScreenTests.swift
+++ b/Clients/iOS/FitWithFriends/UITests/AboutScreenTests.swift
@@ -14,7 +14,46 @@ final class AboutScreenTests: FWFUITestBase {
         // Wait for the home screen to load — allow extra time in CI where app launch is slow
         XCTAssertTrue(app.staticTexts["Fit with Friends"].waitForExistence(timeout: 30))
 
-        // Open the toolbar settings menu and tap Settings
+        navigateToSettings()
+
+        // Verify the settings screen
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Version"].exists)
+
+        takeScreenshot(name: "06_SettingsScreen")
+    }
+
+    func testSettingsShowsRestorePurchasesButton() {
+        launchApp(loggedIn: true)
+        XCTAssertTrue(app.staticTexts["Fit with Friends"].waitForExistence(timeout: 30))
+
+        navigateToSettings()
+
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["RestorePurchasesButton"].waitForExistence(timeout: 5))
+    }
+
+    func testRestorePurchasesShowsSuccessAlert() {
+        launchApp(loggedIn: true)
+        XCTAssertTrue(app.staticTexts["Fit with Friends"].waitForExistence(timeout: 30))
+
+        navigateToSettings()
+
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 5))
+
+        let restoreButton = app.buttons["RestorePurchasesButton"]
+        XCTAssertTrue(restoreButton.waitForExistence(timeout: 5))
+        restoreButton.tap()
+
+        // MockSubscriptionManager.restorePurchases() succeeds immediately; verify success alert
+        XCTAssertTrue(app.alerts["Purchases Restored"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.alerts["Purchases Restored"].staticTexts["Your subscription has been restored."].exists)
+        app.alerts["Purchases Restored"].buttons["OK"].tap()
+    }
+
+    // MARK: - Private
+
+    private func navigateToSettings() {
         let menuButton = app.buttons["SettingsMenu"]
         XCTAssertTrue(menuButton.waitForExistence(timeout: 10))
         menuButton.tap()
@@ -23,11 +62,5 @@ final class AboutScreenTests: FWFUITestBase {
         let settingsButton = app.buttons["SettingsMenuButton"]
         XCTAssertTrue(settingsButton.waitForExistence(timeout: 10))
         settingsButton.tap()
-
-        // Verify the settings screen
-        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.staticTexts["Version"].exists)
-
-        takeScreenshot(name: "06_SettingsScreen")
     }
 }


### PR DESCRIPTION
## Summary

- **Fixes state mismatch** between Apple subscription and backend \`is_pro\`: \`restorePurchases()\` now calls \`POST /subscriptions/validateTransaction\` with the current entitlement's JWS after \`AppStore.sync()\`, mirroring the purchase and background update flows so the backend is correctly updated
- **Adds Restore Purchases button** to SettingsView (Subscription section) with a loading spinner while in-flight and success/error alerts
- **Two new UI tests** in \`AboutScreenTests\` verify the button renders and the success alert appears after tapping

## Test plan

- [x] All unit tests pass locally (\`FitWithFriends_UnitTests\` — 16 suites)
- [x] \`testAboutScreen\` passes
- [x] \`testSettingsShowsRestorePurchasesButton\` passes
- [x] \`testRestorePurchasesShowsSuccessAlert\` passes
- [ ] Manual sandbox test: clear \`is_pro = false\` in DB for a subscriber, tap Restore Purchases in Settings, confirm \`is_pro\` flips back to \`true\` and pro features unlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)