### PR TITLE
Add daily activity details view to Watch app

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends Watch App Tests/WatchCompetitionDetailViewModelTests.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends Watch App Tests/WatchCompetitionDetailViewModelTests.swift
@@ -26,6 +26,7 @@ final class WatchCompetitionDetailViewModelTests: XCTestCase {
         let entries = viewModel.leaderboardEntries
         XCTAssertEqual(entries.map { $0.displayName }, ["Bob B", "Carol C", "Alice A"])
         XCTAssertEqual(entries.map { $0.position }, [1, 2, 3])
+        XCTAssertEqual(entries.map { $0.userId }, ["b", "c", "a"])
     }
 
     func test_leaderboardEntries_markTopThree() {

--- a/Clients/iOS/FitWithFriends/FitWithFriends Watch App Tests/WatchScreenshotTests.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends Watch App Tests/WatchScreenshotTests.swift
@@ -100,6 +100,7 @@ final class WatchScreenshotTests: XCTestCase {
         let view = CompetitionsPagerView(
             overviews: overviews,
             currentUserId: "u_me",
+            competitionManager: MockCompetitionManager(),
             onRefresh: {}
         )
         snapshot(view, named: "01_CompetitionsPager_Active")
@@ -110,6 +111,7 @@ final class WatchScreenshotTests: XCTestCase {
         let view = CompetitionsPagerView(
             overviews: overviews,
             currentUserId: "u_me",
+            competitionManager: MockCompetitionManager(),
             onRefresh: {}
         )
         snapshot(view, named: "02_CompetitionsPager_Winning")
@@ -121,7 +123,7 @@ final class WatchScreenshotTests: XCTestCase {
             competition: overviews[0],
             currentUserId: "u_me"
         )
-        let view = WatchCompetitionDetailView(viewModel: viewModel)
+        let view = WatchCompetitionDetailView(viewModel: viewModel, competitionManager: MockCompetitionManager())
         snapshot(view, named: "03_CompetitionDetail_FullLeaderboard")
     }
 

--- a/Clients/iOS/FitWithFriends/FitWithFriends Watch App/Views/CompetitionsPagerView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends Watch App/Views/CompetitionsPagerView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct CompetitionsPagerView: View {
     let overviews: [CompetitionOverview]
     let currentUserId: String?
+    let competitionManager: ICompetitionManager
     let onRefresh: () async -> Void
 
     var body: some View {
@@ -20,7 +21,8 @@ struct CompetitionsPagerView: View {
                         viewModel: WatchCompetitionDetailViewModel(
                             competition: overview,
                             currentUserId: currentUserId
-                        )
+                        ),
+                        competitionManager: competitionManager
                     )
                 } label: {
                     CompetitionCardView(

--- a/Clients/iOS/FitWithFriends/FitWithFriends Watch App/Views/WatchCompetitionDetailView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends Watch App/Views/WatchCompetitionDetailView.swift
@@ -9,12 +9,21 @@ import SwiftUI
 
 struct WatchCompetitionDetailView: View {
     let viewModel: WatchCompetitionDetailViewModel
+    let competitionManager: ICompetitionManager
 
     var body: some View {
         List {
             Section {
                 ForEach(viewModel.leaderboardEntries, id: \.position) { entry in
-                    WatchUserResultRow(entry: entry, isCompetitionActive: viewModel.isCompetitionActive)
+                    NavigationLink {
+                        WatchUserCompetitionDailyDetailsView(
+                            competitionId: viewModel.competition.competitionId,
+                            userId: entry.userId,
+                            userName: entry.displayName,
+                            competitionManager: competitionManager)
+                    } label: {
+                        WatchUserResultRow(entry: entry, isCompetitionActive: viewModel.isCompetitionActive)
+                    }
                 }
             } header: {
                 Text(viewModel.userPositionDescription)

--- a/Clients/iOS/FitWithFriends/FitWithFriends Watch App/Views/WatchRootView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends Watch App/Views/WatchRootView.swift
@@ -52,6 +52,7 @@ struct WatchRootView: View {
             CompetitionsPagerView(
                 overviews: overviews,
                 currentUserId: objectGraph.authenticationManager.loggedInUserId,
+                competitionManager: objectGraph.competitionManager,
                 onRefresh: { await forceRefresh() }
             )
         }

--- a/Clients/iOS/FitWithFriends/FitWithFriends Watch App/Views/WatchUserCompetitionDailyDetailsView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends Watch App/Views/WatchUserCompetitionDailyDetailsView.swift
@@ -1,0 +1,97 @@
+//
+//  WatchUserCompetitionDailyDetailsView.swift
+//  FitWithFriends Watch App
+//
+//  Created by Dan O'Connor on 5/6/26.
+//
+
+import SwiftUI
+
+struct WatchUserCompetitionDailyDetailsView: View {
+    @StateObject private var viewModel: UserCompetitionDailyDetailsViewModel
+
+    init(competitionId: UUID, userId: String, userName: String, competitionManager: ICompetitionManager) {
+        _viewModel = StateObject(wrappedValue: UserCompetitionDailyDetailsViewModel(
+            competitionManager: competitionManager,
+            competitionId: competitionId,
+            userId: userId,
+            userName: userName))
+    }
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+            } else if let error = viewModel.errorMessage {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            } else if viewModel.dailySummaries.isEmpty {
+                Text("No activity yet")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                List {
+                    Section {
+                        ForEach(viewModel.dailySummaries) { summary in
+                            WatchDailySummaryRow(summary: summary, unit: viewModel.scoringUnit)
+                        }
+                    } header: {
+                        VStack(spacing: 2) {
+                            Text(ScoringValueFormatter.format(viewModel.totalPoints, unit: viewModel.scoringUnit))
+                                .font(.system(.title3, design: .rounded).weight(.bold).monospacedDigit())
+                            Text(viewModel.totalLabel)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 4)
+                    }
+                }
+                #if os(watchOS)
+                .listStyle(.carousel)
+                #endif
+            }
+        }
+        .navigationTitle(viewModel.userName)
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.loadDetails()
+        }
+    }
+}
+
+// MARK: - Daily row
+
+struct WatchDailySummaryRow: View {
+    let summary: DailySummary
+    let unit: ScoringUnit
+
+    private var dateString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter.string(from: summary.date)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack {
+                Text(dateString)
+                    .font(.footnote.weight(.semibold))
+                Spacer()
+                Text(ScoringValueFormatter.format(summary.points, unit: unit))
+                    .font(.footnote.weight(.semibold).monospacedDigit())
+            }
+
+            if unit == .points {
+                Text("\(summary.caloriesBurned)/\(summary.caloriesGoal) Cal · \(summary.exerciseTime)/\(summary.exerciseTimeGoal) Min · \(summary.standTime)/\(summary.standTimeGoal) h")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+        }
+    }
+}

--- a/Clients/iOS/FitWithFriends/FitWithFriends Watch App/WatchCompetitionDetailViewModel.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends Watch App/WatchCompetitionDetailViewModel.swift
@@ -12,6 +12,7 @@ import Foundation
 class WatchCompetitionDetailViewModel {
     struct LeaderboardEntry: Equatable {
         let position: Int
+        let userId: String
         let displayName: String
         let totalPoints: Int
         let pointsToday: Int
@@ -64,6 +65,7 @@ class WatchCompetitionDetailViewModel {
             let position = index + 1
             return LeaderboardEntry(
                 position: position,
+                userId: result.userId,
                 displayName: result.displayName,
                 totalPoints: Int(result.totalPoints ?? 0),
                 pointsToday: Int(result.pointsToday ?? 0),

--- a/Clients/iOS/FitWithFriends/FitWithFriends.xcodeproj/project.pbxproj
+++ b/Clients/iOS/FitWithFriends/FitWithFriends.xcodeproj/project.pbxproj
@@ -335,6 +335,9 @@
 		WATCHAPP00000000000000S1 /* ScoringRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000000B /* ScoringRules.swift */; };
 		WATCHAPP00000000000000S2 /* WorkoutActivityTypeCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000000D /* WorkoutActivityTypeCatalog.swift */; };
 		WATCHAPP00000000000000S3 /* ScoringValueFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000000F /* ScoringValueFormatter.swift */; };
+		WATCHAPP00000000000000V2 /* WatchUserCompetitionDailyDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = WATCHAPP00000000000000V1 /* WatchUserCompetitionDailyDetailsView.swift */; };
+		WATCHAPP00000000000000V3 /* WatchUserCompetitionDailyDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = WATCHAPP00000000000000V1 /* WatchUserCompetitionDailyDetailsView.swift */; };
+		WATCHAPP00000000000000V4 /* UserCompetitionDailyDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000000000005 /* UserCompetitionDailyDetailsViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -573,6 +576,7 @@
 		DE177B1CCDC6233E8E7C737C /* WatchCompetitionDetailViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchCompetitionDetailViewModel.swift; sourceTree = "<group>"; };
 		E2CD78E019B0DB2D6805AEA9 /* WatchRefreshThrottle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchRefreshThrottle.swift; sourceTree = "<group>"; };
 		F77B1DD88CD6AE72A0B332B3 /* WatchUserResultRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchUserResultRow.swift; sourceTree = "<group>"; };
+		WATCHAPP00000000000000V1 /* WatchUserCompetitionDailyDetailsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchUserCompetitionDailyDetailsView.swift; sourceTree = "<group>"; };
 		F8D645D6E45AF6C8C5171425 /* WatchSessionReceiver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchSessionReceiver.swift; sourceTree = "<group>"; };
 		FA97B7481BA2FE74AE5DCB40 /* WatchRefreshThrottleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchRefreshThrottleTests.swift; sourceTree = "<group>"; };
 		FE00000100000000000001A1 /* FitWithFriends_UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FitWithFriends_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -703,6 +707,7 @@
 				9D7C80395F30BDD8142CFDAE /* CompetitionCardView.swift */,
 				5BFBBF09D143D0B2D95F5484 /* WatchCompetitionDetailView.swift */,
 				F77B1DD88CD6AE72A0B332B3 /* WatchUserResultRow.swift */,
+				WATCHAPP00000000000000V1 /* WatchUserCompetitionDailyDetailsView.swift */,
 				6EBB03229B6E9623F4DE5CAA /* SignedOutView.swift */,
 				42E105028519EF7F16754AB2 /* NoCompetitionsView.swift */,
 			);
@@ -1802,6 +1807,7 @@
 				A1B2C3D4E5F6000000000004 /* UserCompetitionDailyDetails.swift in Sources */,
 				A1B2C3D4E5F6000000000006 /* UserCompetitionDailyDetailsViewModel.swift in Sources */,
 				A1B2C3D4E5F6000000000008 /* UserCompetitionDailyDetailsView.swift in Sources */,
+				WATCHAPP00000000000000V3 /* WatchUserCompetitionDailyDetailsView.swift in Sources */,
 				C7BD62F10D25B0300C02BF41 /* WatchObjectGraph.swift in Sources */,
 				4E1D969372A3CF204A9A30E0 /* WatchAuthenticationManager.swift in Sources */,
 				6508F2E348F2D03DFE84786D /* WatchRefreshThrottle.swift in Sources */,
@@ -1904,6 +1910,8 @@
 				WATCHAPP00000000000000S1 /* ScoringRules.swift in Sources */,
 				WATCHAPP00000000000000S2 /* WorkoutActivityTypeCatalog.swift in Sources */,
 				WATCHAPP00000000000000S3 /* ScoringValueFormatter.swift in Sources */,
+				WATCHAPP00000000000000V4 /* UserCompetitionDailyDetailsViewModel.swift in Sources */,
+				WATCHAPP00000000000000V2 /* WatchUserCompetitionDailyDetailsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

- Tapping any user row in the Watch leaderboard now navigates to a per-day breakdown of their activity for the competition
- New `WatchUserCompetitionDailyDetailsView` adapts the existing iOS daily details feature to the watch screen: a carousel `List` with a total-score header and compact date/value rows; ring competitions also show Cal/Min/Stand figures inline
- `UserCompetitionDailyDetailsViewModel` is now compiled into the Watch app target (it was already in the iOS target); no logic changes to the view model itself
- Added `userId` to `WatchCompetitionDetailViewModel.LeaderboardEntry` so the navigation destination can fetch the right user's data
- `competitionManager` is threaded from `WatchRootView` → `CompetitionsPagerView` → `WatchCompetitionDetailView` → `WatchUserCompetitionDailyDetailsView`

## Test plan

- [ ] Build Watch app target — no errors
- [ ] Run `FitWithFriends Watch App Tests` — all pass (including new `userId` assertion in `WatchCompetitionDetailViewModelTests`)
- [ ] Run `FitWithFriends Watch App UITests` — existing leaderboard navigation tests still pass
- [ ] On-device / simulator: tap a user row in the leaderboard → daily details screen appears with correct name in nav title, correct totals, and per-day rows
- [ ] For ring competitions: verify Cal/Min/Stand secondary line appears in each row
- [ ] For non-ring competitions: verify only date + formatted value is shown (no ring sub-line)
- [ ] Back navigation returns to leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)