### PR TITLE
Retry APNs push on InvalidProviderToken and add JWT diagnostic logging

### DIFF
--- a/WebService/FitWithFriends/test/utilities/apnsHelper.test.ts
+++ b/WebService/FitWithFriends/test/utilities/apnsHelper.test.ts
@@ -1,0 +1,164 @@
+import { EventEmitter } from 'events';
+
+/*
+    Unit tests for apnsHelper.
+    These exercise the real (non-test-environment) code paths by resetting the module
+    between tests and mocking the http2 / Azure / SQL dependencies.
+*/
+
+// --- helpers ---
+
+function makeMockStream(statusCode: number, body: string) {
+    const emitter = new EventEmitter();
+    return {
+        on: (event: string, handler: (...args: unknown[]) => void) => { emitter.on(event, handler); return emitter; },
+        write: jest.fn(),
+        end: jest.fn().mockImplementation(() => {
+            setImmediate(() => {
+                emitter.emit('response', { ':status': statusCode });
+                emitter.emit('data', Buffer.from(body));
+                emitter.emit('end');
+            });
+        }),
+    };
+}
+
+function makeMockSession(responses: Array<{ statusCode: number; body: string }>) {
+    let call = 0;
+    const sessionEmitter = new EventEmitter();
+    return {
+        destroyed: false,
+        closed: false,
+        request: jest.fn().mockImplementation(() => {
+            const r = responses[call] ?? responses[responses.length - 1];
+            call++;
+            return makeMockStream(r.statusCode, r.body);
+        }),
+        on: (event: string, handler: (...args: unknown[]) => void) => { sessionEmitter.on(event, handler); return sessionEmitter; },
+    };
+}
+
+// --- test suite ---
+
+describe('apnsHelper - 403 InvalidProviderToken retry', () => {
+    const origEnv = process.env;
+
+    beforeEach(() => {
+        // Reset all module state (cachedToken, apnsSession) between tests.
+        jest.resetModules();
+
+        process.env = {
+            ...origEnv,
+            NODE_ENV: 'production',
+            AZURE_KEYVAULT_URL: 'https://mock-vault.vault.azure.net',
+            APNS_KEY_SECRET_ID: 'mock-secret-name',
+            APNS_KEY_ID: 'MOCK_KEY_ID',
+            APNS_TEAM_ID: 'MOCK_TEAM_ID',
+            APNS_BUNDLE_ID: 'com.example.mock',
+        };
+    });
+
+    afterEach(() => {
+        process.env = origEnv;
+    });
+
+    function setupMocks(session: ReturnType<typeof makeMockSession>) {
+        // Swap in mocks before the module is (re-)required.
+        jest.doMock('node:http2', () => ({ connect: jest.fn().mockReturnValue(session) }));
+
+        jest.doMock('@azure/keyvault-secrets', () => ({
+            SecretClient: jest.fn().mockImplementation(() => ({
+                getSecret: jest.fn().mockResolvedValue({ value: 'mock-pem-value' }),
+            })),
+        }));
+
+        jest.doMock('@azure/identity', () => ({ DefaultAzureCredential: jest.fn() }));
+
+        // Bypass the real PEM parse + JWT sign so we don't need real key material.
+        jest.doMock('jsonwebtoken', () => ({ sign: jest.fn().mockReturnValue('mock-jwt') }));
+        jest.doMock('crypto', () => ({
+            ...jest.requireActual<typeof import('crypto')>('crypto'),
+            createPrivateKey: jest.fn().mockReturnValue({ asymmetricKeyType: 'ec' }),
+        }));
+
+        jest.doMock('../../sql/pushNotifications.queries', () => ({
+            getPushTokensForUser: jest.fn().mockResolvedValue([{ push_token: 'device-token-abc' }]),
+            deletePushToken: jest.fn().mockResolvedValue(undefined),
+        }));
+
+        jest.doMock('../../utilities/userHelpers', () => ({
+            convertUserIdToBuffer: jest.fn((id: string) => Buffer.from(id)),
+        }));
+    }
+
+    test('retries with a fresh token after 403 InvalidProviderToken and marks delivered', async () => {
+        const session = makeMockSession([
+            { statusCode: 403, body: JSON.stringify({ reason: 'InvalidProviderToken' }) },
+            { statusCode: 200, body: '' },
+        ]);
+        setupMocks(session);
+
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendPushNotifications } = require('../../utilities/apnsHelper') as typeof import('../../utilities/apnsHelper');
+
+        const result = await sendPushNotifications([{ userId: 'user-1', title: 'T', body: 'B' }]);
+
+        expect(result.sent).toBe(1);
+        expect(result.failed).toBe(0);
+        expect(result.failures).toHaveLength(0);
+        // Two requests should have been made: original + retry
+        expect(session.request).toHaveBeenCalledTimes(2);
+    });
+
+    test('returns failure with "(after token refresh)" reason when retry also fails', async () => {
+        const session = makeMockSession([
+            { statusCode: 403, body: JSON.stringify({ reason: 'InvalidProviderToken' }) },
+            { statusCode: 403, body: JSON.stringify({ reason: 'InvalidProviderToken' }) },
+        ]);
+        setupMocks(session);
+
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendPushNotifications } = require('../../utilities/apnsHelper') as typeof import('../../utilities/apnsHelper');
+
+        const result = await sendPushNotifications([{ userId: 'user-1', title: 'T', body: 'B' }]);
+
+        expect(result.sent).toBe(0);
+        expect(result.failed).toBe(1);
+        expect(result.failures[0].reason).toContain('after token refresh');
+        expect(session.request).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not retry on other 403 reasons (e.g. BadDeviceToken)', async () => {
+        const session = makeMockSession([
+            { statusCode: 403, body: JSON.stringify({ reason: 'BadDeviceToken' }) },
+        ]);
+        setupMocks(session);
+
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendPushNotifications } = require('../../utilities/apnsHelper') as typeof import('../../utilities/apnsHelper');
+
+        const result = await sendPushNotifications([{ userId: 'user-1', title: 'T', body: 'B' }]);
+
+        expect(result.sent).toBe(0);
+        expect(result.failed).toBe(1);
+        expect(result.failures[0].reason).not.toContain('after token refresh');
+        expect(session.request).toHaveBeenCalledTimes(1);
+    });
+
+    test('retries with a fresh token after 403 ExpiredProviderToken', async () => {
+        const session = makeMockSession([
+            { statusCode: 403, body: JSON.stringify({ reason: 'ExpiredProviderToken' }) },
+            { statusCode: 200, body: '' },
+        ]);
+        setupMocks(session);
+
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendPushNotifications } = require('../../utilities/apnsHelper') as typeof import('../../utilities/apnsHelper');
+
+        const result = await sendPushNotifications([{ userId: 'user-1', title: 'T', body: 'B' }]);
+
+        expect(result.sent).toBe(1);
+        expect(result.failed).toBe(0);
+        expect(session.request).toHaveBeenCalledTimes(2);
+    });
+});

--- a/WebService/FitWithFriends/utilities/apnsHelper.ts
+++ b/WebService/FitWithFriends/utilities/apnsHelper.ts
@@ -152,6 +152,18 @@ async function getAPNSToken(): Promise<string> {
         noTimestamp: true,
     });
 
+    // Decode the JWT header and payload (not the signature) for diagnostic logging.
+    // Both parts are base64url-encoded JSON; the signature is opaque and not logged.
+    try {
+        const [headerB64, payloadB64] = token.split('.');
+        const header = JSON.parse(Buffer.from(headerB64, 'base64url').toString());
+        const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+        console.log(`APNs JWT header: ${JSON.stringify(header)}`);
+        console.log(`APNs JWT payload: ${JSON.stringify(payload)}`);
+    } catch {
+        console.warn('Could not decode APNs JWT for diagnostic logging');
+    }
+
     // Cache for 55 minutes (token is valid for 60)
     cachedToken = token;
     cachedTokenExpiresAt = nowSeconds + 55 * 60;
@@ -242,6 +254,27 @@ async function sendPushNotification(userId: string, pushToken: string, notificat
                 console.error(`Failed to delete invalid push token for userId ${userId}:`, err);
             }
             return { delivered: false, reason: 'APNs 410: device token no longer valid (token deleted)' };
+        } else if (statusCode === 403) {
+            let apnsReason = '';
+            try { apnsReason = (JSON.parse(data) as { reason?: string }).reason ?? ''; } catch { /* non-JSON body */ }
+            if (apnsReason === 'InvalidProviderToken' || apnsReason === 'ExpiredProviderToken') {
+                // APNs rejected our JWT — invalidate the cache and retry once with a fresh token.
+                // This handles mid-run token expiry or revocation without failing the whole batch.
+                console.warn(`APNs 403 ${apnsReason} for userId ${userId} — refreshing token and retrying`);
+                cachedToken = null;
+                cachedTokenExpiresAt = 0;
+                const freshToken = await getAPNSToken();
+                const retry = await makeApnsRequest(`/3/device/${pushToken}`, bodyStr, freshToken, bundleId);
+                if (retry.statusCode >= 200 && retry.statusCode < 300) {
+                    return { delivered: true, reason: '' };
+                }
+                const retryReason = `APNs HTTP ${retry.statusCode} (after token refresh): ${retry.body}`;
+                console.error(`APNs retry failed for userId ${userId}: ${retryReason}`);
+                return { delivered: false, reason: retryReason };
+            }
+            const reason = `APNs HTTP 403: ${data}`;
+            console.error(`APNs request failed with status code 403 for userId ${userId}. Details: ${data}`);
+            return { delivered: false, reason };
         } else if (statusCode < 200 || statusCode >= 300) {
             // Do not throw so we can continue processing other notifications
             const reason = `APNs HTTP ${statusCode}: ${data}`;


### PR DESCRIPTION
## Summary

- On a 403 `InvalidProviderToken` or `ExpiredProviderToken` response from APNs, invalidate the cached JWT and retry once with a freshly signed token. This handles the case where a valid token becomes invalid mid-run (e.g. APNs-side revocation) without failing the rest of the notification batch.
- Add a temporary diagnostic log that decodes and prints the APNs JWT header (`kid`, `alg`) and payload (`iss`, `iat`) each time a new token is generated — makes it easy to verify that `APNS_KEY_ID` and `APNS_TEAM_ID` match what's registered in the Apple Developer portal.
- Add unit tests for the retry logic covering: successful retry, retry also fails, non-retryable 403, and `ExpiredProviderToken`.

## What a reviewer should know

The diagnostic JWT logging is intentionally temporary — it only logs the header and payload (never the signature), so no key material is exposed. It should be removed once the `InvalidProviderToken` production issue is confirmed resolved.

The retry only fires once per notification. If the fresh token is also rejected, the failure is surfaced with an `"(after token refresh)"` suffix in the reason string so it's distinguishable in the warning output.

## Test plan

- [ ] Run `npm test -- --testPathPattern="apnsHelper"` to verify the 4 new unit tests pass
- [ ] Deploy and trigger `performDailyTasks`; check app service logs for `APNs JWT header` / `APNs JWT payload` lines and confirm `kid` and `iss` match the Apple Developer portal
- [ ] Once `InvalidProviderToken` is resolved, remove the diagnostic logging in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)