### PR TITLE
Fix APNs InvalidProviderToken: remove noTimestamp:true so iat is included in JWT

### DIFF
--- a/WebService/FitWithFriends/test/utilities/apnsHelper.test.ts
+++ b/WebService/FitWithFriends/test/utilities/apnsHelper.test.ts
@@ -145,6 +145,22 @@ describe('apnsHelper - 403 InvalidProviderToken retry', () => {
         expect(session.request).toHaveBeenCalledTimes(1);
     });
 
+    test('signs JWT with iat claim (noTimestamp must not be set)', async () => {
+        const jwtSignMock = jest.fn().mockReturnValue('mock-jwt');
+        const session = makeMockSession([{ statusCode: 200, body: '' }]);
+        setupMocks(session);
+        jest.doMock('jsonwebtoken', () => ({ sign: jwtSignMock }));
+
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendPushNotifications } = require('../../utilities/apnsHelper') as typeof import('../../utilities/apnsHelper');
+        await sendPushNotifications([{ userId: 'user-1', title: 'T', body: 'B' }]);
+
+        expect(jwtSignMock).toHaveBeenCalledTimes(1);
+        const [payload, , options] = jwtSignMock.mock.calls[0] as [Record<string, unknown>, unknown, Record<string, unknown>];
+        expect(typeof payload.iat).toBe('number');
+        expect(options).not.toHaveProperty('noTimestamp');
+    });
+
     test('retries with a fresh token after 403 ExpiredProviderToken', async () => {
         const session = makeMockSession([
             { statusCode: 403, body: JSON.stringify({ reason: 'ExpiredProviderToken' }) },

--- a/WebService/FitWithFriends/utilities/apnsHelper.ts
+++ b/WebService/FitWithFriends/utilities/apnsHelper.ts
@@ -149,7 +149,6 @@ async function getAPNSToken(): Promise<string> {
     const token = jwt.sign({ iss: teamId, iat: nowSeconds }, privateKey, {
         algorithm: 'ES256',
         keyid: apnsKeyId,
-        noTimestamp: true,
     });
 
     // Decode the JWT header and payload (not the signature) for diagnostic logging.


### PR DESCRIPTION
## Summary

- `jsonwebtoken` v9's `noTimestamp: true` option **deletes** a manually-provided `iat` field from the payload before signing — it doesn't just skip auto-generating one
- The APNs JWT was being sent with `{"iss":"..."}` and no `iat` claim; APNs requires `iat` to be present and within 1 hour of the current time
- Every push notification attempt failed with `403 InvalidProviderToken`, which triggered an endless refresh-and-retry loop that ended with `429 TooManyProviderTokenUpdates`
- Fix: remove `noTimestamp: true` from the `jwt.sign` call so the manually-supplied `iat: nowSeconds` is preserved in the signed token

## What changed

| File | Change |
|------|--------|
| `WebService/FitWithFriends/utilities/apnsHelper.ts` | Removed `noTimestamp: true` from `jwt.sign` options |
| `WebService/FitWithFriends/test/utilities/apnsHelper.test.ts` | Added regression test asserting `iat` is present and `noTimestamp` is absent |

## Test plan

- [ ] All 5 `apnsHelper` unit tests pass (`npx jest apnsHelper`)
- [ ] Deploy and run `/performDailyTasks` — APNs status codes should be 200, not 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)