### PR TITLE
Fix activity summary upload bugs and improve diagnostics

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/WorkoutData/HealthKitManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/WorkoutData/HealthKitManager.swift
@@ -228,7 +228,7 @@ public class HealthKitManager: IHealthKitManager {
         }
 
         // Get all the various statistics that we care about for today (step count, stairs climbed, etc.)
-        for quantityType in HealthKitManager.quantityTypesToObserve {
+        for quantityType in HealthKitManager.quantityTypesToQueryStatistics {
             dispatchGroup.enter()
             getQuantityForDay(quantityTypeId: quantityType, date: now) { error, result in
                 defer {
@@ -484,6 +484,11 @@ public class HealthKitManager: IHealthKitManager {
                 }
 
                 updatedActivitySummaries.append(activitySummary)
+            }
+
+            Logger.traceInfo(message: "Uploading \(updatedActivitySummaries.count) activity summaries")
+            for summary in updatedActivitySummaries {
+                Logger.traceVerbose(message: "  \(summary.date.formatted(date: .abbreviated, time: .omitted)): cal=\(summary.activeCaloriesBurned)/\(summary.activeCaloriesGoal) ex=\(summary.exerciseTime)/\(summary.exerciseTimeGoal) stand=\(summary.standTime)/\(summary.standTimeGoal) steps=\(summary.stepCount ?? 0) dist=\(summary.distanceWalkingRunning ?? 0)m flights=\(summary.flightsClimbed ?? 0)")
             }
 
             self.activityDataService.reportActivitySummaries(updatedActivitySummaries) { error in

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/WorkoutData/HealthKitManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/WorkoutData/HealthKitManager.swift
@@ -411,6 +411,7 @@ public class HealthKitManager: IHealthKitManager {
             return
         }
 
+        let calendar = Calendar.current
         let resultQueue = DispatchQueue(label: "reportActivitySummariesQueue")
         let dispatchGroup = DispatchGroup()
 
@@ -428,7 +429,12 @@ public class HealthKitManager: IHealthKitManager {
                 }
 
                 for activityResult in activityResults {
-                    activitySummaries[activityResult.date] = activityResult
+                    // Normalize to midnight so the key matches the startOfDay keys used by
+                    // the statistics query results. HKActivitySummary.dateComponents(for:).date
+                    // can carry sub-millisecond precision that differs from startOfDay, causing
+                    // Set<Date> to treat the same calendar day as two distinct entries.
+                    let normalizedDate = calendar.startOfDay(for: activityResult.date)
+                    activitySummaries[normalizedDate] = activityResult
                 }
             }
 

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/WorkoutData/HealthKitManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/WorkoutData/HealthKitManager.swift
@@ -50,6 +50,14 @@ public class HealthKitManager: IHealthKitManager {
         .flightsClimbed
     ]
 
+    /// Subset of quantityTypesToObserve that are supported by HKStatisticsQuery (cumulative sum).
+    /// .activeEnergyBurned and .appleExerciseTime are covered by HKActivitySummary, not statistics queries.
+    private static let quantityTypesToQueryStatistics: [HKQuantityTypeIdentifier] = [
+        .stepCount,
+        .distanceWalkingRunning,
+        .flightsClimbed
+    ]
+
     /// Hold onto a reference to our query so it doesn't get deinitialized
     private var observerQuery: HKQuery?
 
@@ -428,7 +436,7 @@ public class HealthKitManager: IHealthKitManager {
         }
 
         var quantityResults: [HKQuantityTypeIdentifier: [Date: StatisticDTO]] = [:]
-        for quantityType in HealthKitManager.quantityTypesToObserve {
+        for quantityType in HealthKitManager.quantityTypesToQueryStatistics {
             dispatchGroup.enter()
             getAllDailySumsSinceLastUpdate(for: quantityType) { success, result in
                 resultQueue.sync {
@@ -569,7 +577,7 @@ public class HealthKitManager: IHealthKitManager {
         }
 
         dispatchGroup.notify(queue: .global()) {
-            completion(hasFailure, results)
+            completion(!hasFailure, results)
         }
     }
 
@@ -622,8 +630,8 @@ public class HealthKitManager: IHealthKitManager {
             let date = Date(timeIntervalSince1970: lastUpdate)
 
             // Only query a max of 30 days of data
-            let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: date)!
-            if thirtyDaysAgo > date {
+            let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: Date())!
+            if date < thirtyDaysAgo {
                 Logger.traceWarning(message: "Last update for \(key) is more than thirty days ago. Only returning 30 days of data. Last update time: \(date). Thirty days ago is \(thirtyDaysAgo)")
                 return thirtyDaysAgo
             }

--- a/Clients/iOS/FitWithFriends/UnitTests/HealthKitManagerTests.swift
+++ b/Clients/iOS/FitWithFriends/UnitTests/HealthKitManagerTests.swift
@@ -316,6 +316,98 @@ final class HealthKitManagerTests: XCTestCase {
                        "Today's summary should have its step count correctly attributed")
     }
 
+    /// Verifies that the last-update timestamp is persisted after a fully successful sync.
+    ///
+    /// Bug: getAllDailySumsSinceLastUpdate called completion(hasFailure, results) instead of
+    /// completion(!hasFailure, results). When all HealthKit queries succeeded (hasFailure=false),
+    /// the caller received success=false → containsFailures=true → lastActivityDataUpdateKey was
+    /// never written → the query window kept expanding on every subsequent sync.
+    func test_successfulSync_savesLastUpdateTimestamp() {
+        let calendar = Calendar.current
+
+        // Set a known start point so the query window is short
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: Date())!
+        userDefaults.set(yesterday.timeIntervalSince1970, forKey: HealthKitManager.lastActivityDataUpdateKey)
+
+        healthStoreWrapper.return_statisticsQuery_statistics = [
+            HKQuantityType(.stepCount): StatisticDTO(sumValue: 3_000),
+            HKQuantityType(.distanceWalkingRunning): StatisticDTO(sumValue: 2_000),
+            HKQuantityType(.flightsClimbed): StatisticDTO(sumValue: 5),
+        ]
+
+        let todayStart = calendar.startOfDay(for: Date())
+        healthStoreWrapper.return_activitySummaryQuery_activitySummaries = [
+            ActivitySummaryDTO(date: todayStart,
+                               activeEnergyBurned: 200, activeEnergyBurnedGoal: 500,
+                               appleExerciseTime: 10, appleExerciseTimeGoal: 30,
+                               appleStandHours: 5, appleStandHoursGoal: 12)
+        ]
+
+        healthKitManager.setupObserverQueries()
+
+        let completionExpectation = expectation(description: "Update handler completion should be called")
+        healthStoreWrapper.param_updateHandler!(
+            healthStoreWrapper.return_observerQuery!,
+            Set([HKQuantityType(.stepCount)]),
+            { completionExpectation.fulfill() },
+            nil
+        )
+
+        waitForExpectations(timeout: 10)
+
+        let savedTimestamp = userDefaults.double(forKey: HealthKitManager.lastActivityDataUpdateKey)
+        XCTAssertGreaterThan(savedTimestamp, yesterday.timeIntervalSince1970,
+                             "lastActivityDataUpdateKey should be updated after a successful sync; it was stuck at the old value, meaning containsFailures was wrongly true")
+    }
+
+    /// Verifies that a stale last-update date older than 30 days is clamped to 30 days ago.
+    ///
+    /// Bug: thirtyDaysAgo was calculated relative to the stored date (not today), so
+    /// `thirtyDaysAgo > date` was always false. Users with a stored date from months ago
+    /// would have their query window expand to cover that entire period, making the sync
+    /// time out the 60-second background-task budget before any data could be uploaded.
+    func test_staleLastUpdateTimestamp_isCappedToThirtyDays() {
+        let calendar = Calendar.current
+
+        // Set the last update to 90 days ago (well beyond the 30-day cap)
+        let ninetyDaysAgo = calendar.date(byAdding: .day, value: -90, to: Date())!
+        userDefaults.set(ninetyDaysAgo.timeIntervalSince1970, forKey: HealthKitManager.lastActivityDataUpdateKey)
+
+        healthStoreWrapper.return_statisticsQuery_statistics = [
+            HKQuantityType(.stepCount): StatisticDTO(sumValue: 500),
+            HKQuantityType(.distanceWalkingRunning): StatisticDTO(sumValue: 300),
+            HKQuantityType(.flightsClimbed): StatisticDTO(sumValue: 2),
+        ]
+
+        let todayStart = calendar.startOfDay(for: Date())
+        healthStoreWrapper.return_activitySummaryQuery_activitySummaries = [
+            ActivitySummaryDTO(date: todayStart,
+                               activeEnergyBurned: 100, activeEnergyBurnedGoal: 500,
+                               appleExerciseTime: 5, appleExerciseTimeGoal: 30,
+                               appleStandHours: 3, appleStandHoursGoal: 12)
+        ]
+
+        healthKitManager.setupObserverQueries()
+
+        let completionExpectation = expectation(description: "Update handler completion should be called")
+        healthStoreWrapper.param_updateHandler!(
+            healthStoreWrapper.return_observerQuery!,
+            Set([HKQuantityType(.stepCount)]),
+            { completionExpectation.fulfill() },
+            nil
+        )
+
+        waitForExpectations(timeout: 10)
+
+        // With 3 statistics types (step, distance, flights) and at most 31 days (30-day cap + today),
+        // the maximum expected call count is 31 × 3 = 93.
+        // Without the fix, a 90-day stale timestamp would produce 90 × 3 = 270 calls.
+        let callCount = healthStoreWrapper.executeStatisticsQueryCallCount
+        XCTAssertLessThanOrEqual(callCount, 93,
+                                 "With a 90-day stale timestamp the 30-day cap should limit statistics queries to ≤93 (31 days × 3 types), got \(callCount)")
+        XCTAssertGreaterThan(callCount, 0, "Should have executed at least one statistics query")
+    }
+
     /// Regression test for a closure capture bug in getAllDailySumsSinceLastUpdate.
     ///
     /// The loop variable `date` was captured by reference in the async callback closure.

--- a/WebService/FitWithFriends/routes/activityData.ts
+++ b/WebService/FitWithFriends/routes/activityData.ts
@@ -80,7 +80,10 @@ router.post('/dailySummary', function (req, res) {
     // PostgreSQL cannot update the same target row twice in one statement.
     const summaryByDate = new Map<string, typeof summariesToInsert[0]>();
     for (const summary of summariesToInsert) {
-        const key = summary.date;
+        // Normalize to a YYYY-MM-DD UTC date string so that two timestamps representing
+        // the same calendar day (e.g. identical moments in different timezone formats) are
+        // treated as one row — matching how PostgreSQL stores the value in a `date` column.
+        const key = new Date(summary.date).toISOString().split('T')[0];
         const existing = summaryByDate.get(key);
         if (existing) {
             existing.caloriesBurned = Math.max(existing.caloriesBurned, summary.caloriesBurned);


### PR DESCRIPTION
## Summary

- **Bug fix (iOS):** Three compounding bugs in `HealthKitManager` prevented activity summary data from ever being uploaded — inverted success boolean in `sendStatisticsQueryResults`, unsupported types in the statistics loop, and a broken 30-day cap. Fixed all three so `lastActivityDataUpdateKey` is now saved correctly after each successful sync.
- **Bug fix (iOS + server):** First upload after the date-attribution fix (PR #109) caused a PostgreSQL `ON CONFLICT DO UPDATE command cannot affect row a second time` 500 error. Root cause: sub-millisecond timestamp differences between `HKActivitySummary.dateComponents(for:).date` and `Calendar.startOfDay` made two entries for the same calendar day look distinct. Fixed by normalising dates to `startOfDay` on the iOS side and to a UTC `YYYY-MM-DD` string on the server dedup key.
- **Bug fix (iOS):** `getCurrentActivitySummary` (home screen) iterated over `quantityTypesToObserve` when calling `getQuantityForDay`, which has a `default: completion(HttpError.generic, nil)` branch for `.activeEnergyBurned` and `.appleExerciseTime`. This generated error log spam on every home screen load. Switched to `quantityTypesToQueryStatistics` to match the upload path.
- **Logging:** Added per-summary verbose log line before each upload showing all uploaded values (cal burned/goal, exercise time/goal, stand time/goal, steps, distance, flights) to make future diagnostics easier.

## Test plan

- [ ] Build and run on device; confirm no "Failed to get quantity ActiveEnergyBurned/AppleExerciseTime" errors appear in logs when home screen loads
- [ ] Confirm activity summary upload log shows per-day values: `cal=X/Y ex=A/B stand=C/D steps=N dist=Mm flights=F`
- [ ] Confirm competition standings reflect today's activity after a fresh launch
- [ ] Run iOS unit tests (`FitWithFriends` scheme, `-only-testing:FitWithFriends_UnitTests`)
- [ ] Run backend tests (`PGHOST=localhost PGPORT=5432 PGUSER=testuser PGPASSWORD=testpass PGDATABASE=fitwithfriends PGUSESSL=0 npm test` from `WebService/FitWithFriends/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)