### PR TITLE
Fix timezone mismatch causing today's activity summary to be split and stored on the wrong date

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/WorkoutData/DTOs/ActivitySummaryDTO.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/WorkoutData/DTOs/ActivitySummaryDTO.swift
@@ -26,12 +26,19 @@ public struct ActivitySummaryDTO {
     public let hkActivitySummary: HKActivitySummary
 
     public init?(hkActivitySummary: HKActivitySummary) {
-        guard let date = hkActivitySummary.dateComponents(for: Calendar.current).date else {
+        // HKActivitySummary.dateComponents(for:) returns midnight UTC for the local calendar day
+        // regardless of the calendar passed in. Extract year/month/day from the UTC date, then
+        // reconstruct as local midnight so the date aligns with statistics query results
+        // (which use Calendar.current.startOfDay on local dates).
+        var utcCalendar = Calendar.current
+        utcCalendar.timeZone = TimeZone.gmt
+        guard let utcMidnight = hkActivitySummary.dateComponents(for: utcCalendar).date,
+              let localMidnight = Calendar.current.date(from: utcCalendar.dateComponents([.year, .month, .day], from: utcMidnight)) else {
             Logger.traceError(message: "Tried to initialize ActivitySummaryDTO without valid date")
             return nil
         }
 
-        self.date = date
+        self.date = Calendar.current.startOfDay(for: localMidnight)
 
         activeEnergyBurned = UInt(round(hkActivitySummary.activeEnergyBurned.doubleValue(for: .largeCalorie())))
         activeEnergyBurnedGoal = UInt(round(hkActivitySummary.activeEnergyBurnedGoal.doubleValue(for: .largeCalorie())))

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/WorkoutData/HealthKitManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/WorkoutData/HealthKitManager.swift
@@ -177,9 +177,6 @@ public class HealthKitManager: IHealthKitManager {
         var today = calendar.dateComponents([.day, .month, .year, .era], from: now)
         today.calendar = calendar
 
-        var utcCalendar = Calendar.current
-        utcCalendar.timeZone = TimeZone.gmt
-
         Logger.traceVerbose(message: "Begin get activity summary for \(today)")
 
         guard healthStoreWrapper.isHealthDataAvailable else {
@@ -206,10 +203,9 @@ public class HealthKitManager: IHealthKitManager {
                 return
             }
 
-            // The summaries are being returned as UTC dates, so we need to parse them with the UTC calendar to get the day to match
-            // the current day in our local timezone
+            // ActivitySummaryDTO.date is local midnight, so compare using the local calendar
             let summary = summaries?.first {
-                let summaryDate = utcCalendar.dateComponents([.day, .month, .year, .era], from: $0.date)
+                let summaryDate = calendar.dateComponents([.day, .month, .year, .era], from: $0.date)
                 return summaryDate.year == today.year && summaryDate.month == today.month && summaryDate.day == today.day
             }
 
@@ -429,10 +425,9 @@ public class HealthKitManager: IHealthKitManager {
                 }
 
                 for activityResult in activityResults {
-                    // Normalize to midnight so the key matches the startOfDay keys used by
-                    // the statistics query results. HKActivitySummary.dateComponents(for:).date
-                    // can carry sub-millisecond precision that differs from startOfDay, causing
-                    // Set<Date> to treat the same calendar day as two distinct entries.
+                    // ActivitySummaryDTO.date is already local midnight; startOfDay is a
+                    // no-op for dates produced by the HK initializer but guards against
+                    // sub-millisecond drift in dates constructed elsewhere (e.g. unit tests).
                     let normalizedDate = calendar.startOfDay(for: activityResult.date)
                     activitySummaries[normalizedDate] = activityResult
                 }

--- a/WebService/FitWithFriends/routes/activityData.ts
+++ b/WebService/FitWithFriends/routes/activityData.ts
@@ -62,7 +62,9 @@ router.post('/dailySummary', function (req, res) {
 
         summariesToInsert.push({
             userId: userIdBuffer,
-            date: dateStr,
+            // Normalize to YYYY-MM-DD (UTC) so PostgreSQL stores the correct calendar day
+            // regardless of the server's local timezone setting.
+            date: date.toISOString().split('T')[0],
             caloriesBurned,
             caloriesGoal,
             exerciseTime,


### PR DESCRIPTION
## Summary

- **iOS**: `HKActivitySummary.dateComponents(for:)` always returns midnight UTC regardless of the calendar argument. Applying `calendar.startOfDay()` (local time) to that UTC midnight mapped the ring-data entry to the *previous* local day's key, while statistics (steps/distance/flights) used the correct local-midnight key. The two never merged — producing two separate `ActivitySummary` objects sent to the backend: one with ring data only, one with stats only.
- **Backend**: The deduplication logic correctly identified both entries as the same UTC calendar day, but passed the raw `dateStr` of the first-seen entry to PostgreSQL. That string encoded `"2026-05-17T20:00:00.000-0400"` (8 PM local = midnight UTC May 18). A PostgreSQL server running in a local timezone strips the offset and stores `2026-05-17` — yesterday instead of today.

## Changes

**`ActivitySummaryDTO.swift`** — `init(hkActivitySummary:)` now extracts year/month/day from the HK UTC date using a UTC calendar, then reconstructs the date as local midnight. This makes the DTO date consistent with how statistics dates are keyed (`calendar.startOfDay()`), so the two data sets correctly merge into one `ActivitySummary`.

**`HealthKitManager.swift`** — `getCurrentActivitySummary`'s filter now compares using the local calendar (since `ActivitySummaryDTO.date` is now local midnight, not UTC midnight). Updated the stale `reportActivitySummaries` comment to reflect the new invariant.

**`activityData.ts`** — Normalises the `date` field to `YYYY-MM-DD` UTC format (`date.toISOString().split('T')[0]`) before inserting, so PostgreSQL always receives an unambiguous date string regardless of the server's local timezone setting.

## Test plan

- [ ] All 10 `HealthKitManagerTests` pass locally (verified)
- [ ] All 27 `activityData` backend tests pass locally (verified)
- [ ] Run the app on a device and confirm today's activity summary shows a single entry with both ring data and statistics in the debugger
- [ ] Confirm the correct date appears in the database after syncing

🤖 Generated with [Claude Code](https://claude.com/claude-code)