### PR TITLE
Fix is_pro not synced to server on subscription restore

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Subscriptions/SubscriptionManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Subscriptions/SubscriptionManager.swift
@@ -96,6 +96,7 @@ public class SubscriptionManager: ISubscriptionManager, ObservableObject {
 
     func checkSubscriptionStatus() async {
         var foundValidEntitlement = false
+        var jwsToValidate: String? = nil
 
         for await entitlement in Transaction.currentEntitlements {
             guard case .verified(let transaction) = entitlement else {
@@ -114,7 +115,22 @@ public class SubscriptionManager: ISubscriptionManager, ObservableObject {
 
             Logger.traceInfo(message: "Found valid Pro entitlement")
             foundValidEntitlement = true
+            jwsToValidate = entitlement.jwsRepresentation
             break
+        }
+
+        // Sync with the server so is_pro is always up-to-date.
+        // This is critical for the restore-purchases path: already-finished transactions
+        // are NOT delivered via Transaction.updates (which listenForTransactionUpdates uses),
+        // so the server would never learn about them without this explicit validation call.
+        if let jws = jwsToValidate {
+            do {
+                let status = try await subscriptionService.validateTransaction(signedTransaction: jws)
+                Logger.traceInfo(message: "Subscription synced with server, isPro: \(status.isPro)")
+            } catch {
+                Logger.traceError(message: "Failed to sync subscription status with server", error: error)
+                // Local state still reflects StoreKit entitlements even if server sync fails
+            }
         }
 
         let validEntitlement = foundValidEntitlement


### PR DESCRIPTION
## Summary

- `checkSubscriptionStatus()` was setting `isUserPro` locally but never calling `validateTransaction` on the server, so the backend `is_pro` field was never updated during the restore-purchases flow
- Already-finished transactions are not delivered via `Transaction.updates` (which `listenForTransactionUpdates` relies on), so the server validation that works for new purchases was silently skipped for restores
- Fix: capture the `jwsRepresentation` from the `VerificationResult<Transaction>` in `currentEntitlements` and call `subscriptionService.validateTransaction()` when a valid entitlement is found — keeping the server in sync on every `checkSubscriptionStatus()` call (app launch, restore, post-purchase)

## Test plan

- [ ] Verify that a fresh install / re-install with an existing Pro subscription correctly sets `is_pro = true` on the server after app launch
- [ ] Verify that tapping "Restore Purchases" in the Pro Upgrade view sets `is_pro = true` on the server
- [ ] Verify that a new purchase still works correctly (no regression — server is updated as before, plus now also via `checkSubscriptionStatus`)
- [ ] Verify that a user with no active subscription does not trigger a spurious server call (no `jwsToValidate` means no network request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)