### PR TITLE
Bump app version to 2.0.0

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends/Info-Debug.plist
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Info-Debug.plist
@@ -26,7 +26,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>2.0.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -41,7 +41,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.1.0</string>
+	<string>2.0.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIDeviceFamily</key>

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Info-Release.plist
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Info-Release.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>2.0.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary

Update version numbers across all platforms to 2.0.0.

## Changes

- **Backend** (WebService/FitWithFriends/package.json): 1.0.0 → 2.0.0
- **iOS Release** (Clients/iOS/FitWithFriends/FitWithFriends/Info-Release.plist): 1.1.0 → 2.0.0
- **iOS Debug** (Clients/iOS/FitWithFriends/FitWithFriends/Info-Debug.plist): 1.1.0 → 2.0.0

This is a major version bump indicating significant changes to the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)