### PR TITLE
Fix ended competitions showing "0 pts today"

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Competitions/CompetitionOverviewViewModel.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Competitions/CompetitionOverviewViewModel.swift
@@ -344,10 +344,11 @@ public class CompetitionOverviewViewModel: ObservableObject {
             }
         }()
 
-        // Today's delta in the comp's own unit. Don't synthesize a value when the
-        // comp hasn't started — the empty state will show "Not started" instead.
+        // Today's delta in the comp's own unit. Only shown while the competition is
+        // actively running — suppressed before it starts and after it ends so we
+        // never show "+0 pts today" on a finished competition.
         var todayDelta: TodayDelta? = nil
-        if overview.hasCompetitionStarted, userPosition > 0,
+        if overview.isCompetitionActive, userPosition > 0,
            let userResult = allResults.first(where: { $0.userId == userId }),
            let today = userResult.pointsToday {
             let value = ScoringValueFormatter.formatCompact(today, unit: overview.scoringUnit)


### PR DESCRIPTION
## Summary

- `todayDelta` in `CompetitionOverviewViewModel` was gated on `hasCompetitionStarted` but not `!hasCompetitionEnded`. For ended competitions `pointsToday` is `0` (not `nil`), so the home card was rendering **"+0 pts today"** instead of nothing.
- Changed the guard to `isCompetitionActive` (`hasCompetitionStarted && !hasCompetitionEnded`), which suppresses the delta for both not-yet-started and ended/archived competitions. The rest of the ended-competition UI (rank, "You finished in 2nd", days-left chip hidden) was already correct.

## Test plan

- [ ] Create a competition that has already ended — home card shows rank (e.g. "2nd of 4") with no today-delta block, and "You finished in 2nd" in the status line.
- [ ] Active competition still shows the today delta (e.g. "+235 pts today").
- [ ] Not-yet-started competition shows "Not started" with no today delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)