### PR TITLE
Send competition notifications at each user's local 8am

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Competitions/CompetitionManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Competitions/CompetitionManager.swift
@@ -169,6 +169,10 @@ public class CompetitionManager: ICompetitionManager, ObservableObject {
     func getUserCompetitionDetails(competitionId: UUID, userId: String) async throws -> UserCompetitionDailyDetails {
         return try await competitionService.getUserCompetitionDetails(competitionId: competitionId, userId: userId)
     }
+
+    func markCompetitionNotificationsSeen(competitionId: UUID) async throws {
+        try await competitionService.markCompetitionNotificationsSeen(competitionId: competitionId)
+    }
 }
 
 #if !os(watchOS)

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Competitions/ICompetitionManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Competitions/ICompetitionManager.swift
@@ -86,4 +86,9 @@ protocol ICompetitionManager: AnyObject {
     ///   - userId: The target user id
     /// - Returns: The user's daily competition details
     func getUserCompetitionDetails(competitionId: UUID, userId: String) async throws -> UserCompetitionDailyDetails
+
+    /// Marks the end-of-competition notifications as seen for the logged-in user, suppressing
+    /// the server's fallback push. Called when the end-of-competition screen is shown.
+    /// - Parameter competitionId: The competition id
+    func markCompetitionNotificationsSeen(competitionId: UUID) async throws
 }

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/CompetitionService.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/CompetitionService.swift
@@ -106,6 +106,11 @@ public class CompetitionService: ServiceBase, ICompetitionService {
                                                                            body: requestBody)
     }
 
+    public func markCompetitionNotificationsSeen(competitionId: UUID) async throws {
+        let _: EmptyResponse = try await makeRequestWithUserAuthentication(url: "\(serverEnvironmentManager.baseUrl)/competitions/\(competitionId.uuidString)/notificationsSeen",
+                                                                           method: .post)
+    }
+
     public func getUserCompetitionDetails(competitionId: UUID, userId: String) async throws -> UserCompetitionDailyDetails {
         let ianaTimezone = TimeZone.current.identifier
 

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/ICompetitionService.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/ICompetitionService.swift
@@ -67,6 +67,12 @@ public protocol ICompetitionService {
     /// - Parameter competitionId: The competition to join
     func joinPublicCompetition(competitionId: UUID) async throws
 
+    /// Marks the end-of-competition notifications as seen for the logged-in user, so the
+    /// server won't also send the (now-redundant) push. Called when the end-of-competition
+    /// screen is shown.
+    /// - Parameter competitionId: The competition id
+    func markCompetitionNotificationsSeen(competitionId: UUID) async throws
+
     /// Get daily activity details for a specific user within a competition.
     /// Both the logged-in user and the target user must be members of the competition.
     /// Only returns data within the competition's date range.

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/IUserService.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/IUserService.swift
@@ -24,4 +24,9 @@ public protocol IUserService {
 
     /// Permanently deletes the currently authenticated user's account and all associated data.
     func deleteAccount() async throws
+
+    /// Reports the device's current IANA timezone so the server schedules end-of-competition
+    /// notifications at the user's local morning.
+    /// - Parameter timezone: An IANA timezone identifier (e.g. `TimeZone.current.identifier`)
+    func reportTimezone(_ timezone: String) async throws
 }

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/UserService.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/UserService.swift
@@ -13,6 +13,13 @@ public class UserService: ServiceBase, IUserService {
         let _: EmptyResponse = try await makeRequestWithUserAuthentication(url: url, method: .delete)
     }
 
+    public func reportTimezone(_ timezone: String) async throws {
+        let url = "\(serverEnvironmentManager.baseUrl)/users/timezone"
+        let _: EmptyResponse = try await makeRequestWithUserAuthentication(url: url,
+                                                                           method: .post,
+                                                                           body: ["timezone": timezone])
+    }
+
     /// Creates a new user with the given credentials/user info. Will return an error if the username already exists
     public func createUser(firstName: String,
                     lastName: String,

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Mocks/MockCompetitionManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Mocks/MockCompetitionManager.swift
@@ -196,4 +196,16 @@ public class MockCompetitionManager: ICompetitionManager {
 
         return details
     }
+
+    public var param_markCompetitionNotificationsSeen_competitionId: UUID?
+    public var return_markCompetitionNotificationsSeen_error: Error?
+    public var markCompetitionNotificationsSeenCallCount = 0
+    public func markCompetitionNotificationsSeen(competitionId: UUID) async throws {
+        markCompetitionNotificationsSeenCallCount += 1
+        param_markCompetitionNotificationsSeen_competitionId = competitionId
+
+        if let error = return_markCompetitionNotificationsSeen_error {
+            throw error
+        }
+    }
 }

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Mocks/MockCompetitionService.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Mocks/MockCompetitionService.swift
@@ -163,4 +163,16 @@ public class MockCompetitionService: ICompetitionService {
             throw HttpError.generic
         }
     }
+
+    public var param_markCompetitionNotificationsSeen_competitionId: UUID?
+    public var return_markCompetitionNotificationsSeen_error: Error?
+    public var markCompetitionNotificationsSeenCallCount = 0
+    public func markCompetitionNotificationsSeen(competitionId: UUID) async throws {
+        markCompetitionNotificationsSeenCallCount += 1
+        param_markCompetitionNotificationsSeen_competitionId = competitionId
+
+        if let error = return_markCompetitionNotificationsSeen_error {
+            throw error
+        }
+    }
 }

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Mocks/MockUserService.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Mocks/MockUserService.swift
@@ -25,6 +25,17 @@ public class MockUserService: IUserService {
         }
     }
 
+    public var param_reportTimezone_timezone: String?
+    public var return_reportTimezone_error: Error?
+    public var reportTimezoneCallCount = 0
+    public func reportTimezone(_ timezone: String) async throws {
+        reportTimezoneCallCount += 1
+        param_reportTimezone_timezone = timezone
+        if let error = return_reportTimezone_error {
+            throw error
+        }
+    }
+
     public func createUser(firstName: String,
                     lastName: String,
                     userId: String,

--- a/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Home/CompetitionEndAlertViewModel.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Home/CompetitionEndAlertViewModel.swift
@@ -71,6 +71,10 @@ class CompetitionEndAlertViewModel: ObservableObject {
         guard currentEndCompetition == nil, let next = pendingCompetitions.first else { return }
         pendingCompetitions.removeFirst()
 
+        // The user is about to see the final results, so tell the server to suppress
+        // the fallback push for this competition.
+        markNotificationsSeen(for: next.competitionId)
+
         let position = userPosition(in: next) ?? Int.max
         let willShowConfetti = position <= 3
         if willShowConfetti {
@@ -201,6 +205,17 @@ class CompetitionEndAlertViewModel: ObservableObject {
         let sorted = competition.currentResults.sorted()
         guard let idx = sorted.firstIndex(where: { $0.userId == userId }) else { return nil }
         return idx + 1
+    }
+
+    private func markNotificationsSeen(for competitionId: UUID) {
+        guard let manager = competitionManager else { return }
+        Task.detached {
+            do {
+                try await manager.markCompetitionNotificationsSeen(competitionId: competitionId)
+            } catch {
+                Logger.traceWarning(message: "Failed to mark competition notifications seen: \(error)")
+            }
+        }
     }
 
     private func seenKey(for competitionId: UUID) -> String {

--- a/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Home/HomepageViewModel.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Home/HomepageViewModel.swift
@@ -85,6 +85,17 @@ public class HomepageViewModel: ObservableObject {
         let activitySummaryTask = Task { await self.refreshTodayActivitySummary() }
         let competitionTask = Task { await self.competitionManager.refreshCompetitionOverviews() }
 
+        // Report the device timezone on every foreground so notifications track the
+        // user's current location. Fire-and-forget — failure just falls back to the
+        // competition timezone server-side.
+        Task.detached { [userService] in
+            do {
+                try await userService.reportTimezone(TimeZone.current.identifier)
+            } catch {
+                Logger.traceWarning(message: "Failed to report timezone: \(error)")
+            }
+        }
+
         await activitySummaryTask.value
         await competitionTask.value
     }

--- a/Clients/iOS/FitWithFriends/UnitTests/CompetitionEndAlertViewModelTests.swift
+++ b/Clients/iOS/FitWithFriends/UnitTests/CompetitionEndAlertViewModelTests.swift
@@ -102,6 +102,29 @@ final class CompetitionEndAlertViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.currentAlertCompetition)
     }
 
+    func test_archivedCompetition_marksNotificationsSeen() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 1)
+
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+        // The mark-seen call is fire-and-forget in a detached Task
+        await waitUntil(mockCompetitionManager.markCompetitionNotificationsSeenCallCount > 0)
+
+        XCTAssertEqual(mockCompetitionManager.markCompetitionNotificationsSeenCallCount, 1)
+        XCTAssertEqual(mockCompetitionManager.param_markCompetitionNotificationsSeen_competitionId, competition.competitionId)
+    }
+
+    func test_nonArchivedCompetition_doesNotMarkNotificationsSeen() async {
+        let vm = makeVM()
+        let competition = makeCompetition(state: .processingResults)
+
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.shouldShowConfetti == false)
+
+        XCTAssertEqual(mockCompetitionManager.markCompetitionNotificationsSeenCallCount, 0)
+    }
+
     func test_notStartedOrActiveCompetition_doesNotShowAlert() async {
         let vm = makeVM()
         let competition = makeCompetition(state: .notStartedOrActive)

--- a/WebService/CreateDatabaseTables.sql
+++ b/WebService/CreateDatabaseTables.sql
@@ -123,7 +123,8 @@ CREATE TABLE public.users (
     created_date date NOT NULL,
     apple_original_transaction_id text,
     subscription_expires_date timestamp,
-    is_bot boolean DEFAULT false NOT NULL
+    is_bot boolean DEFAULT false NOT NULL,
+    preferred_timezone text
 );
 
 
@@ -137,7 +138,9 @@ ALTER TABLE public.users OWNER TO postgres;
 CREATE TABLE public.users_competitions (
     user_id bytea NOT NULL,
     competition_id uuid NOT NULL,
-    final_points real
+    final_points real,
+    sent_processing_notification boolean DEFAULT false NOT NULL,
+    sent_complete_notification boolean DEFAULT false NOT NULL
 );
 
 

--- a/WebService/FitWithFriends/routes/admin.ts
+++ b/WebService/FitWithFriends/routes/admin.ts
@@ -11,7 +11,13 @@ import { CompetitionState } from '../utilities/enums/CompetitionState';
 import { handleError } from '../utilities/errorHelpers';
 import * as UserHelpers from '../utilities/userHelpers';
 import { getCompetitionStandings, validateScoringRulesInput } from '../utilities/competitionStandingsHelper';
+import { isWithinNotificationWindow, isValidTimeZone } from '../utilities/timezoneHelpers';
 import * as cryptoHelpers from '../utilities/cryptoHelpers';
+
+// Competitions stay eligible for end-of-competition notifications for a few days
+// after they finish, giving every member's local morning window time to arrive
+// (even the westmost timezones, the morning after archival) plus slack for retries.
+const NOTIFICATION_WINDOW_DAYS = 3;
 
 const router = express.Router();
 
@@ -189,6 +195,14 @@ router.post('/performDailyTasks', async function (req, res) {
         errors.push(['processRecentlyEndedCompetitions', err]);
     }
 
+    // Runs after the state transitions above so a competition that advanced this
+    // run is immediately eligible to notify members whose local morning has arrived.
+    try {
+        taskResults.push({ name: 'sendCompetitionNotifications', ...await sendDueCompetitionNotifications(now) });
+    } catch (err) {
+        errors.push(['sendCompetitionNotifications', err]);
+    }
+
     try {
         taskResults.push({ name: 'deleteExpiredRefreshTokens', result: await deleteExpiredRefreshTokens(now) });
     } catch (err) {
@@ -226,47 +240,32 @@ router.post('/performDailyTasks', async function (req, res) {
     }
 });
 
-// Get recently ended competitions
-// Move them to the processing state
-// Send push notifications to users
+// Get recently ended competitions and move them to the processing state.
+// Push notifications are sent separately, per-user at each member's local 8am,
+// by sendDueCompetitionNotifications.
 async function processesRecentlyEndedCompetitions(now: Date): Promise<string> {
     const competitionsToMoveToProcessing = await CompetitionQueries.getCompetitionsInState({
         state: CompetitionState.NotStartedOrActive,
         finishedBeforeDate: now
      });
 
+     if (competitionsToMoveToProcessing.length === 0) {
+        return 'No competitions to process';
+     }
+
      // Update competitions to processing state
      await Promise.all(competitionsToMoveToProcessing.map(competition => {
          return CompetitionQueries.updateCompetitionState({ competitionId: competition.competition_id, newState: CompetitionState.ProcessingResults });
      }));
 
-     if (competitionsToMoveToProcessing.length === 0) {
-        return 'No competitions to process';
-     }
-
-     // For each competition, get the users and send a notification
-     const notifications = [];
-     for (const competition of competitionsToMoveToProcessing) {
-         const users = await CompetitionQueries.getUsersForCompetition({ competitionId: competition.competition_id });
-         for (const user of users) {
-             notifications.push({
-                 userId: UserHelpers.convertBufferToUserId(user.user_id),
-                 title: `The competition "${competition.display_name}" has ended!`,
-                 body: 'The final results are being processed and will be posted tomorrow',
-             });
-         }
-     }
-
-     if (notifications.length > 0) {
-         await sendPushNotifications(notifications);
-     }
-
      return `Moved ${competitionsToMoveToProcessing.length} competition(s) to processing state`;
 }
 
-// Get competitions that have been in the processing state for more than 24 hours
-// Move them to the archived state and archive results
-// Send final results push notifications
+// Get competitions that have been in the processing state for more than 24 hours.
+// Freeze each member's final points and move the competition to the archived state.
+// The final-results push notifications are sent separately, per-user at each
+// member's local 8am, by sendDueCompetitionNotifications (which reads the frozen
+// final_points to compute placement).
 async function archiveCompetitions(now: Date): Promise<{ result: string; warning?: string }> {
     const olderThan24Hrs = new Date(now.getTime() - (24 * 60 * 60 * 1000));
      const competitionsToArchive = await CompetitionQueries.getCompetitionsInState({
@@ -278,11 +277,9 @@ async function archiveCompetitions(now: Date): Promise<{ result: string; warning
         return { result: 'No competitions to archive' };
     }
 
-    let totalSent = 0;
-    let totalFailed = 0;
-    const notificationErrors: string[] = [];
+    const pointsErrors: string[] = [];
 
-    // Calculate the final results for each competition
+    // Calculate and freeze the final results for each competition
     for (const competition of competitionsToArchive) {
         try {
             const competitionUsers = await CompetitionQueries.getUsersForCompetition({ competitionId: competition.competition_id });
@@ -302,65 +299,20 @@ async function archiveCompetitions(now: Date): Promise<{ result: string; warning
                 })),
                 competition.iana_timezone);
 
-            // Send final results push notifications
-            // Sort users by most points to fewest
-            const sortedResults = Object.values(competitionResults).sort((a, b) => b.activityPoints - a.activityPoints);
-            const notifications = [];
-            for (let i = 0; i < sortedResults.length; i++) {
-                const userPoints = sortedResults[i];
-                let place: string;
-                switch (i) {
-                    case 0:
-                        place = 'first';
-                        break;
-                    case 1:
-                        place = 'second';
-                        break;
-                    case 2:
-                        place = 'third';
-                        break;
-                    default:
-                        place = `${i + 1}th`;
-                }
-                notifications.push({
-                    userId: userPoints.userId,
-                    title: `The competition "${competition.display_name}" has ended!`,
-                    body: `You came in ${place} place with ${userPoints.activityPoints} points!`,
-                });
-            }
-
-            // Run notifications and final-point DB writes in parallel.
-            // Both must be inside the same Promise.all so a rejection from either
-            // is caught by the surrounding try/catch instead of becoming an
-            // unhandled rejection that crashes the process.
-            try {
-                const [sendResult] = await Promise.all([
-                    sendPushNotifications(notifications),
-                    Promise.all(Object.values(competitionResults).map(userPoints =>
-                        CompetitionQueries.updateCompetitionFinalPoints({
-                            userId: UserHelpers.convertUserIdToBuffer(userPoints.userId),
-                            competitionId: competition.competition_id,
-                            finalPoints: userPoints.activityPoints
-                        })
-                    ))
-                ]);
-                totalSent += sendResult.sent;
-                totalFailed += sendResult.failed;
-                if (sendResult.failures.length > 0) {
-                    const failureDetails = sendResult.failures
-                        .map(f => `userId=${f.userId}: ${f.reason}`)
-                        .join('; ');
-                    console.warn(`Push notification failures for competition ${competition.competition_id}: ${failureDetails}`);
-                    notificationErrors.push(`competition ${competition.competition_id} — ${failureDetails}`);
-                }
-            } catch (notifErr) {
-                const msg = `competition ${competition.competition_id}: ${(notifErr as Error).message}`;
-                notificationErrors.push(msg);
-                console.error(`Error sending notifications/writing final points for ${msg}`, notifErr);
-            }
+            // Freeze each user's final points. The per-user results notification
+            // (sent later, at each member's local 8am) ranks members from these
+            // frozen values, so they must be written before the competition archives.
+            await Promise.all(Object.values(competitionResults).map(userPoints =>
+                CompetitionQueries.updateCompetitionFinalPoints({
+                    userId: UserHelpers.convertUserIdToBuffer(userPoints.userId),
+                    competitionId: competition.competition_id,
+                    finalPoints: userPoints.activityPoints
+                })
+            ));
         } catch (err) {
             // Log the error but continue processing other competitions
             console.error(`Error calculating final results for competition ${competition.competition_id}:`, err);
+            pointsErrors.push(`competition ${competition.competition_id}: ${(err as Error).message}`);
         }
     }
 
@@ -369,20 +321,128 @@ async function archiveCompetitions(now: Date): Promise<{ result: string; warning
         return CompetitionQueries.updateCompetitionState({ competitionId: competition.competition_id, newState: CompetitionState.Archived });
     }));
 
-    const total = totalSent + totalFailed;
-    const result = `Archived ${competitionsToArchive.length} competition(s), ${totalSent}/${total} push notifications sent`;
-
-    const warningParts: string[] = [];
-    if (totalFailed > 0) {
-        warningParts.push(`${totalFailed} push notification(s) failed to deliver`);
-    }
-    if (notificationErrors.length > 0) {
-        warningParts.push(`notification/points errors: ${notificationErrors.join(', ')}`);
-    }
-
-    return warningParts.length > 0
-        ? { result, warning: warningParts.join('; ') }
+    const result = `Archived ${competitionsToArchive.length} competition(s)`;
+    return pointsErrors.length > 0
+        ? { result, warning: `final-points errors: ${pointsErrors.join(', ')}` }
         : { result };
+}
+
+// Converts a 1-based placement into the wording used in the results notification.
+function ordinalPlace(place: number): string {
+    switch (place) {
+        case 1: return 'first';
+        case 2: return 'second';
+        case 3: return 'third';
+        default: return `${place}th`;
+    }
+}
+
+// Sends the two end-of-competition push notifications per-user, at each member's
+// local ~8am (their preferred_timezone, falling back to the competition timezone):
+//   - "processing" while the competition is in the ProcessingResults state
+//   - "final results" once it has archived (placement read from frozen final_points)
+// Delivery is tracked per (user, competition) via the sent_* flags so each member
+// is notified once at their own local morning. A member is marked only when a push
+// is actually delivered, so throttled/failed sends retry on the next run. Bots are
+// excluded by the query. Seeing the results in-app also satisfies the flags (the
+// client marks them), so this is a fallback for members who haven't opened the app.
+async function sendDueCompetitionNotifications(now: Date): Promise<{ result: string; warning?: string }> {
+    const finishedAfter = new Date(now.getTime() - NOTIFICATION_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+    const pending = await CompetitionQueries.getPendingCompetitionNotifications({
+        finishedAfter,
+        processingState: CompetitionState.ProcessingResults,
+        archivedState: CompetitionState.Archived
+    });
+
+    if (pending.length === 0) {
+        return { result: 'No competition notifications to send' };
+    }
+
+    // Group the pending member rows by competition
+    const byCompetition = new Map<string, typeof pending>();
+    for (const row of pending) {
+        const list = byCompetition.get(row.competition_id) ?? [];
+        list.push(row);
+        byCompetition.set(row.competition_id, list);
+    }
+
+    let totalSent = 0;
+    const warnings: string[] = [];
+
+    for (const [competitionId, rows] of byCompetition) {
+        const state = rows[0].state;
+        const displayName = rows[0].display_name;
+        const competitionTimezone = rows[0].iana_timezone;
+
+        // Build the placement ranking once (archived only) from frozen final_points,
+        // across ALL members including bots so positions match the leaderboard.
+        let placeByUser: Map<string, number> | null = null;
+        if (state === CompetitionState.Archived) {
+            const allMembers = await CompetitionQueries.getUsersForCompetition({ competitionId });
+            const ranked = allMembers
+                .map(m => ({ userId: UserHelpers.convertBufferToUserId(m.user_id), points: m.final_points ?? 0 }))
+                .sort((a, b) => b.points - a.points);
+            placeByUser = new Map(ranked.map((m, i) => [m.userId, i + 1]));
+        }
+
+        // Select the members whose local morning window has arrived and who still
+        // need this competition's notification.
+        const notifications: { userId: string; title: string; body: string }[] = [];
+        const eligibleUserIds: string[] = [];
+        for (const row of rows) {
+            const alreadySent = state === CompetitionState.Archived
+                ? row.sent_complete_notification
+                : row.sent_processing_notification;
+            if (alreadySent) continue;
+
+            // Use the member's reported timezone, falling back to the competition's
+            // when it's missing or not a resolvable IANA zone.
+            const tz = (row.preferred_timezone && isValidTimeZone(row.preferred_timezone))
+                ? row.preferred_timezone
+                : competitionTimezone;
+            if (!isWithinNotificationWindow(now, tz)) continue;
+
+            eligibleUserIds.push(row.user_id);
+            if (state === CompetitionState.Archived) {
+                const place = placeByUser!.get(row.user_id) ?? 0;
+                const points = row.final_points ?? 0;
+                notifications.push({
+                    userId: row.user_id,
+                    title: `The competition "${displayName}" has ended!`,
+                    body: `You came in ${ordinalPlace(place)} place with ${points} points!`,
+                });
+            } else {
+                notifications.push({
+                    userId: row.user_id,
+                    title: `The competition "${displayName}" has ended!`,
+                    body: 'The final results are being processed and will be posted tomorrow',
+                });
+            }
+        }
+
+        if (notifications.length === 0) continue;
+
+        const sendResult = await sendPushNotifications(notifications);
+        totalSent += sendResult.sent;
+
+        // Mark only the members we actually delivered to. Undelivered members keep
+        // their flag false and are retried on the next run (still in their window).
+        const markSent = state === CompetitionState.Archived
+            ? CompetitionQueries.markCompleteNotificationSent
+            : CompetitionQueries.markProcessingNotificationSent;
+        await Promise.all(sendResult.succeededUserIds.map(userId =>
+            markSent({ userId: UserHelpers.convertUserIdToBuffer(userId), competitionId })
+        ));
+
+        const undelivered = eligibleUserIds.length - sendResult.succeededUserIds.length;
+        if (undelivered > 0) {
+            const kind = state === CompetitionState.Archived ? 'results' : 'processing';
+            warnings.push(`competition ${competitionId}: ${undelivered} ${kind} notification(s) not delivered (will retry)`);
+        }
+    }
+
+    const result = `Sent ${totalSent} competition notification(s)`;
+    return warnings.length > 0 ? { result, warning: warnings.join('; ') } : { result };
 }
 
 async function deleteExpiredRefreshTokens(now: Date): Promise<string> {

--- a/WebService/FitWithFriends/routes/competitions.ts
+++ b/WebService/FitWithFriends/routes/competitions.ts
@@ -345,6 +345,27 @@ router.post('/leave', function (req, res) {
         });
 });
 
+// Marks the end-of-competition notifications as satisfied for the authenticated
+// user. The client calls this when it shows the end-of-competition screen, so the
+// server doesn't also send the now-redundant push at the user's local 8am.
+router.post('/:competitionId/notificationsSeen', function (req, res) {
+    const competitionId: string = req.params['competitionId'];
+    const userIdBuffer = convertUserIdToBuffer(res.locals.oauth.token.user.id);
+
+    CompetitionQueries.isUserInCompetition({ userId: userIdBuffer, competitionId })
+        .then(membership => {
+            if (!membership.length || membership[0].count === 0) {
+                handleError(null, 401, 'User is not a member of the competition', res);
+                return;
+            }
+
+            CompetitionQueries.markCompleteNotificationSent({ userId: userIdBuffer, competitionId })
+                .then(() => res.sendStatus(200))
+                .catch(error => handleError(error, 500, 'Error marking competition notifications as seen', res));
+        })
+        .catch(error => handleError(error, 500, 'Error checking competition membership', res));
+});
+
 // Returns an overview of the given competition that contains a list of users and their current points for the competition
 // The user must be a member of this competition in order to receive the data
 //

--- a/WebService/FitWithFriends/routes/users.ts
+++ b/WebService/FitWithFriends/routes/users.ts
@@ -2,8 +2,9 @@
 import { validateAppleIdToken } from '../utilities/appleIdAuthenticationHelpers';
 import { handleError } from '../utilities/errorHelpers';
 import express from 'express';
-import { ICreateUserParams, createUser, deleteUser } from '../sql/users.queries';
+import { ICreateUserParams, createUser, deleteUser, updateUserTimezone } from '../sql/users.queries';
 import { convertUserIdToBuffer } from '../utilities/userHelpers';
+import { isValidTimeZone } from '../utilities/timezoneHelpers';
 import oauthServer from '../oauth/server';
 
 const router = express.Router();
@@ -55,13 +56,19 @@ router.post('/userFromAppleID', function (req, res) {
             const hexUserId = userId.replace(/\./g, '');
             const currentDate = new Date();
 
+            // Optional: the client may report the device timezone at sign-up so the
+            // first competition's notifications already fire at the user's local 8am.
+            const timezone: string | undefined = req.body['timezone'];
+            const preferredTimezone = (timezone && isValidTimeZone(timezone)) ? timezone : null;
+
             const createUserParams: ICreateUserParams = {
                 userId: convertUserIdToBuffer(hexUserId),
                 firstName: firstName,
                 lastName: lastName,
                 maxActiveCompetitions: 1,
                 isPro: false,
-                createdDate: currentDate
+                createdDate: currentDate,
+                preferredTimezone
             };
             createUser(createUserParams)
                 .then(_result => {
@@ -74,6 +81,23 @@ router.post('/userFromAppleID', function (req, res) {
         .catch(error => {
             handleError(error, 401, 'Token failed validation', res);
         });
+});
+
+// Updates the authenticated user's preferred timezone. The client calls this on
+// launch / when the device timezone changes so end-of-competition notifications
+// are scheduled at the user's local morning.
+router.post('/timezone', oauthServer.authenticate(), function (req, res) {
+    const timezone: string | undefined = req.body['timezone'];
+
+    if (!timezone || !timezone.length || timezone.length > 255 || !isValidTimeZone(timezone)) {
+        handleError(null, 400, 'Missing or invalid timezone', res);
+        return;
+    }
+
+    const userId: string = res.locals.oauth.token.user.id;
+    updateUserTimezone({ userId: convertUserIdToBuffer(userId), preferredTimezone: timezone })
+        .then(() => res.sendStatus(200))
+        .catch((error: Error) => handleError(error, 500, 'Unexpected error while updating timezone', res));
 });
 
 // Deletes the currently authenticated user's account and all associated data

--- a/WebService/FitWithFriends/sql/competitions.queries.ts
+++ b/WebService/FitWithFriends/sql/competitions.queries.ts
@@ -530,6 +530,134 @@ export function updateCompetitionFinalPoints(params: IUpdateCompetitionFinalPoin
 }
 
 
+/** 'GetPendingCompetitionNotifications' parameters type */
+export interface IGetPendingCompetitionNotificationsParams {
+  archivedState: number;
+  finishedAfter: DateOrString;
+  processingState: number;
+}
+
+/** 'GetPendingCompetitionNotifications' return type */
+export interface IGetPendingCompetitionNotificationsResult {
+  competition_id: string;
+  display_name: string;
+  final_points: number | null;
+  iana_timezone: string;
+  preferred_timezone: string | null;
+  sent_complete_notification: boolean;
+  sent_processing_notification: boolean;
+  state: number;
+  user_id: string;
+}
+
+/** 'GetPendingCompetitionNotifications' query type */
+export interface IGetPendingCompetitionNotificationsQuery {
+  params: IGetPendingCompetitionNotificationsParams;
+  result: IGetPendingCompetitionNotificationsResult;
+}
+
+const getPendingCompetitionNotificationsIR: any = {"usedParamSet":{"finishedAfter":true,"processingState":true,"archivedState":true},"params":[{"name":"finishedAfter","required":true,"transform":{"type":"scalar"},"locs":[{"a":853,"b":867}]},{"name":"processingState","required":true,"transform":{"type":"scalar"},"locs":[{"a":919,"b":935}]},{"name":"archivedState","required":true,"transform":{"type":"scalar"},"locs":[{"a":1001,"b":1015}]}],"statement":"                                                                                                                                                                                                                                                                                                                                                                                                 \nSELECT\n    c.competition_id,\n    c.display_name,\n    c.iana_timezone,\n    c.state,\n    encode(uc.user_id::bytea, 'hex') AS \"user_id!\",\n    u.preferred_timezone,\n    uc.final_points,\n    uc.sent_processing_notification AS \"sent_processing_notification!\",\n    uc.sent_complete_notification AS \"sent_complete_notification!\"\nFROM competitions c\nJOIN users_competitions uc ON uc.competition_id = c.competition_id\nJOIN users u ON u.user_id = uc.user_id\nWHERE c.end_date >= :finishedAfter!\n  AND u.is_bot = false\n  AND (\n        (c.state = :processingState! AND uc.sent_processing_notification = false)\n     OR (c.state = :archivedState! AND uc.sent_complete_notification = false)\n  )"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ *                                                                                                                                                                                                                                                                                                                                                                                                  
+ * SELECT
+ *     c.competition_id,
+ *     c.display_name,
+ *     c.iana_timezone,
+ *     c.state,
+ *     encode(uc.user_id::bytea, 'hex') AS "user_id!",
+ *     u.preferred_timezone,
+ *     uc.final_points,
+ *     uc.sent_processing_notification AS "sent_processing_notification!",
+ *     uc.sent_complete_notification AS "sent_complete_notification!"
+ * FROM competitions c
+ * JOIN users_competitions uc ON uc.competition_id = c.competition_id
+ * JOIN users u ON u.user_id = uc.user_id
+ * WHERE c.end_date >= :finishedAfter!
+ *   AND u.is_bot = false
+ *   AND (
+ *         (c.state = :processingState! AND uc.sent_processing_notification = false)
+ *      OR (c.state = :archivedState! AND uc.sent_complete_notification = false)
+ *   )
+ * ```
+ */
+export function getPendingCompetitionNotifications(params: IGetPendingCompetitionNotificationsParams): Promise<Array<IGetPendingCompetitionNotificationsResult>> {
+  return import('@pgtyped/runtime').then(pgtyped => {
+    const getPendingCompetitionNotifications = new pgtyped.PreparedQuery<IGetPendingCompetitionNotificationsParams,IGetPendingCompetitionNotificationsResult>(getPendingCompetitionNotificationsIR);
+    return getPendingCompetitionNotifications.run(params, DatabaseConnectionPool);
+  });
+}
+
+
+/** 'MarkProcessingNotificationSent' parameters type */
+export interface IMarkProcessingNotificationSentParams {
+  competitionId: string;
+  userId: Buffer;
+}
+
+/** 'MarkProcessingNotificationSent' return type */
+export type IMarkProcessingNotificationSentResult = void;
+
+/** 'MarkProcessingNotificationSent' query type */
+export interface IMarkProcessingNotificationSentQuery {
+  params: IMarkProcessingNotificationSentParams;
+  result: IMarkProcessingNotificationSentResult;
+}
+
+const markProcessingNotificationSentIR: any = {"usedParamSet":{"userId":true,"competitionId":true},"params":[{"name":"userId","required":true,"transform":{"type":"scalar"},"locs":[{"a":82,"b":89}]},{"name":"competitionId","required":true,"transform":{"type":"scalar"},"locs":[{"a":112,"b":126}]}],"statement":"UPDATE users_competitions\nSET sent_processing_notification = true\nWHERE user_id = :userId! AND competition_id = :competitionId!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE users_competitions
+ * SET sent_processing_notification = true
+ * WHERE user_id = :userId! AND competition_id = :competitionId!
+ * ```
+ */
+export function markProcessingNotificationSent(params: IMarkProcessingNotificationSentParams): Promise<Array<IMarkProcessingNotificationSentResult>> {
+  return import('@pgtyped/runtime').then(pgtyped => {
+    const markProcessingNotificationSent = new pgtyped.PreparedQuery<IMarkProcessingNotificationSentParams,IMarkProcessingNotificationSentResult>(markProcessingNotificationSentIR);
+    return markProcessingNotificationSent.run(params, DatabaseConnectionPool);
+  });
+}
+
+
+/** 'MarkCompleteNotificationSent' parameters type */
+export interface IMarkCompleteNotificationSentParams {
+  competitionId: string;
+  userId: Buffer;
+}
+
+/** 'MarkCompleteNotificationSent' return type */
+export type IMarkCompleteNotificationSentResult = void;
+
+/** 'MarkCompleteNotificationSent' query type */
+export interface IMarkCompleteNotificationSentQuery {
+  params: IMarkCompleteNotificationSentParams;
+  result: IMarkCompleteNotificationSentResult;
+}
+
+const markCompleteNotificationSentIR: any = {"usedParamSet":{"userId":true,"competitionId":true},"params":[{"name":"userId","required":true,"transform":{"type":"scalar"},"locs":[{"a":308,"b":315}]},{"name":"competitionId","required":true,"transform":{"type":"scalar"},"locs":[{"a":338,"b":352}]}],"statement":"                                                                                                                                                                                              \nUPDATE users_competitions\nSET sent_complete_notification = true, sent_processing_notification = true\nWHERE user_id = :userId! AND competition_id = :competitionId!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ *                                                                                                                                                                                               
+ * UPDATE users_competitions
+ * SET sent_complete_notification = true, sent_processing_notification = true
+ * WHERE user_id = :userId! AND competition_id = :competitionId!
+ * ```
+ */
+export function markCompleteNotificationSent(params: IMarkCompleteNotificationSentParams): Promise<Array<IMarkCompleteNotificationSentResult>> {
+  return import('@pgtyped/runtime').then(pgtyped => {
+    const markCompleteNotificationSent = new pgtyped.PreparedQuery<IMarkCompleteNotificationSentParams,IMarkCompleteNotificationSentResult>(markCompleteNotificationSentIR);
+    return markCompleteNotificationSent.run(params, DatabaseConnectionPool);
+  });
+}
+
+
 /** 'GetPublicCompetitions' parameters type */
 export interface IGetPublicCompetitionsParams {
   activeState: number;

--- a/WebService/FitWithFriends/sql/competitions.sql
+++ b/WebService/FitWithFriends/sql/competitions.sql
@@ -58,6 +58,45 @@ UPDATE users_competitions
 SET final_points = :finalPoints!
 WHERE user_id = :userId! AND competition_id = :competitionId!;
 
+/* @name GetPendingCompetitionNotifications */
+/* One row per (member, competition) that still needs an end-of-competition push.
+   Restricted to competitions that finished recently (within the caller's window)
+   and are in the processing or archived state. Bots are excluded — they have no
+   push tokens. The processing notification is skipped once the competition has
+   archived (handled by selecting on the per-state flag). */
+SELECT
+    c.competition_id,
+    c.display_name,
+    c.iana_timezone,
+    c.state,
+    encode(uc.user_id::bytea, 'hex') AS "user_id!",
+    u.preferred_timezone,
+    uc.final_points,
+    uc.sent_processing_notification AS "sent_processing_notification!",
+    uc.sent_complete_notification AS "sent_complete_notification!"
+FROM competitions c
+JOIN users_competitions uc ON uc.competition_id = c.competition_id
+JOIN users u ON u.user_id = uc.user_id
+WHERE c.end_date >= :finishedAfter!
+  AND u.is_bot = false
+  AND (
+        (c.state = :processingState! AND uc.sent_processing_notification = false)
+     OR (c.state = :archivedState! AND uc.sent_complete_notification = false)
+  );
+
+/* @name MarkProcessingNotificationSent */
+UPDATE users_competitions
+SET sent_processing_notification = true
+WHERE user_id = :userId! AND competition_id = :competitionId!;
+
+/* @name MarkCompleteNotificationSent */
+/* Seeing/receiving the final results makes the processing notification moot, so
+   both flags are satisfied. Also used by the client when the user views the
+   end-of-competition screen. */
+UPDATE users_competitions
+SET sent_complete_notification = true, sent_processing_notification = true
+WHERE user_id = :userId! AND competition_id = :competitionId!;
+
 /* @name GetPublicCompetitions */
 SELECT c.competition_id, c.display_name, c.start_date, c.end_date, c.iana_timezone, c.state,
        COUNT(uc.user_id)::INTEGER AS "member_count!"

--- a/WebService/FitWithFriends/sql/users.queries.ts
+++ b/WebService/FitWithFriends/sql/users.queries.ts
@@ -10,6 +10,7 @@ export interface ICreateUserParams {
   isPro: boolean;
   lastName?: string | null | void;
   maxActiveCompetitions: number;
+  preferredTimezone?: string | null | void;
   userId: Buffer;
 }
 
@@ -22,18 +23,49 @@ export interface ICreateUserQuery {
   result: ICreateUserResult;
 }
 
-const createUserIR: any = {"usedParamSet":{"userId":true,"firstName":true,"lastName":true,"maxActiveCompetitions":true,"isPro":true,"createdDate":true},"params":[{"name":"userId","required":true,"transform":{"type":"scalar"},"locs":[{"a":105,"b":112}]},{"name":"firstName","required":true,"transform":{"type":"scalar"},"locs":[{"a":115,"b":125}]},{"name":"lastName","required":false,"transform":{"type":"scalar"},"locs":[{"a":128,"b":136}]},{"name":"maxActiveCompetitions","required":true,"transform":{"type":"scalar"},"locs":[{"a":139,"b":161}]},{"name":"isPro","required":true,"transform":{"type":"scalar"},"locs":[{"a":164,"b":170}]},{"name":"createdDate","required":true,"transform":{"type":"scalar"},"locs":[{"a":173,"b":185}]}],"statement":"INSERT INTO users(user_id, first_name, last_name, max_active_competitions, is_pro, created_date) VALUES (:userId!, :firstName!, :lastName, :maxActiveCompetitions!, :isPro!, :createdDate!)"};
+const createUserIR: any = {"usedParamSet":{"userId":true,"firstName":true,"lastName":true,"maxActiveCompetitions":true,"isPro":true,"createdDate":true,"preferredTimezone":true},"params":[{"name":"userId","required":true,"transform":{"type":"scalar"},"locs":[{"a":125,"b":132}]},{"name":"firstName","required":true,"transform":{"type":"scalar"},"locs":[{"a":135,"b":145}]},{"name":"lastName","required":false,"transform":{"type":"scalar"},"locs":[{"a":148,"b":156}]},{"name":"maxActiveCompetitions","required":true,"transform":{"type":"scalar"},"locs":[{"a":159,"b":181}]},{"name":"isPro","required":true,"transform":{"type":"scalar"},"locs":[{"a":184,"b":190}]},{"name":"createdDate","required":true,"transform":{"type":"scalar"},"locs":[{"a":193,"b":205}]},{"name":"preferredTimezone","required":false,"transform":{"type":"scalar"},"locs":[{"a":208,"b":225}]}],"statement":"INSERT INTO users(user_id, first_name, last_name, max_active_competitions, is_pro, created_date, preferred_timezone) VALUES (:userId!, :firstName!, :lastName, :maxActiveCompetitions!, :isPro!, :createdDate!, :preferredTimezone)"};
 
 /**
  * Query generated from SQL:
  * ```
- * INSERT INTO users(user_id, first_name, last_name, max_active_competitions, is_pro, created_date) VALUES (:userId!, :firstName!, :lastName, :maxActiveCompetitions!, :isPro!, :createdDate!)
+ * INSERT INTO users(user_id, first_name, last_name, max_active_competitions, is_pro, created_date, preferred_timezone) VALUES (:userId!, :firstName!, :lastName, :maxActiveCompetitions!, :isPro!, :createdDate!, :preferredTimezone)
  * ```
  */
 export function createUser(params: ICreateUserParams): Promise<Array<ICreateUserResult>> {
   return import('@pgtyped/runtime').then(pgtyped => {
     const createUser = new pgtyped.PreparedQuery<ICreateUserParams,ICreateUserResult>(createUserIR);
     return createUser.run(params, DatabaseConnectionPool);
+  });
+}
+
+
+/** 'UpdateUserTimezone' parameters type */
+export interface IUpdateUserTimezoneParams {
+  preferredTimezone: string;
+  userId: Buffer;
+}
+
+/** 'UpdateUserTimezone' return type */
+export type IUpdateUserTimezoneResult = void;
+
+/** 'UpdateUserTimezone' query type */
+export interface IUpdateUserTimezoneQuery {
+  params: IUpdateUserTimezoneParams;
+  result: IUpdateUserTimezoneResult;
+}
+
+const updateUserTimezoneIR: any = {"usedParamSet":{"preferredTimezone":true,"userId":true},"params":[{"name":"preferredTimezone","required":true,"transform":{"type":"scalar"},"locs":[{"a":38,"b":56}]},{"name":"userId","required":true,"transform":{"type":"scalar"},"locs":[{"a":74,"b":81}]}],"statement":"UPDATE users SET preferred_timezone = :preferredTimezone! WHERE user_id = :userId!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE users SET preferred_timezone = :preferredTimezone! WHERE user_id = :userId!
+ * ```
+ */
+export function updateUserTimezone(params: IUpdateUserTimezoneParams): Promise<Array<IUpdateUserTimezoneResult>> {
+  return import('@pgtyped/runtime').then(pgtyped => {
+    const updateUserTimezone = new pgtyped.PreparedQuery<IUpdateUserTimezoneParams,IUpdateUserTimezoneResult>(updateUserTimezoneIR);
+    return updateUserTimezone.run(params, DatabaseConnectionPool);
   });
 }
 

--- a/WebService/FitWithFriends/sql/users.sql
+++ b/WebService/FitWithFriends/sql/users.sql
@@ -1,5 +1,8 @@
 /* @name CreateUser */
-INSERT INTO users(user_id, first_name, last_name, max_active_competitions, is_pro, created_date) VALUES (:userId!, :firstName!, :lastName, :maxActiveCompetitions!, :isPro!, :createdDate!);
+INSERT INTO users(user_id, first_name, last_name, max_active_competitions, is_pro, created_date, preferred_timezone) VALUES (:userId!, :firstName!, :lastName, :maxActiveCompetitions!, :isPro!, :createdDate!, :preferredTimezone);
+
+/* @name UpdateUserTimezone */
+UPDATE users SET preferred_timezone = :preferredTimezone! WHERE user_id = :userId!;
 
 /* @name GetUserName */
 SELECT first_name, last_name FROM users WHERE user_id = :userId!;

--- a/WebService/FitWithFriends/test/routes/admin.test.ts
+++ b/WebService/FitWithFriends/test/routes/admin.test.ts
@@ -231,12 +231,15 @@ describe('performDailyTasks - archiveCompetitions', () => {
         expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 200 }));
         expect(response.data.errors).toHaveLength(0);
         expect(getTaskResult(response, 'archiveCompetitions')).toContain('Archived 1 competition(s)');
-        expect(getTaskResult(response, 'archiveCompetitions')).toContain('2/2 push notifications sent');
         expect(getTaskWarning(response, 'archiveCompetitions')).toBeUndefined();
 
         // Verify the competition state was updated to Archived
         const competition = await TestSQL.getCompetition({ competitionId });
         expect(competition[0].state).toBe(CompetitionState.Archived);
+
+        // Final points are frozen at archival (read by the per-user results notification)
+        const members = await TestSQL.getUsersInCompetition({ competitionId });
+        expect(members.every(m => m.final_points !== null)).toBe(true);
     });
 
     test('does not archive competitions in ProcessingResults state for less than 24 hours', async () => {
@@ -295,7 +298,7 @@ describe('performDailyTasks - archiveCompetitions', () => {
         expect(competition[0].state).toBe(CompetitionState.Archived);
     });
 
-    test('sets a warning when users have no registered push token', async () => {
+    test('archives even when a member has no registered push token', async () => {
         const competitionId = crypto.randomUUID();
         const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
 
@@ -317,15 +320,204 @@ describe('performDailyTasks - archiveCompetitions', () => {
             competitionId
         });
 
+        // Archival is independent of push delivery (which now happens per-user in
+        // sendCompetitionNotifications), so it succeeds without warnings.
         const response = await RequestUtilities.makeAdminPostRequest('admin/performDailyTasks', {});
         expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 200 }));
         expect(response.data.errors).toHaveLength(0);
         expect(getTaskResult(response, 'archiveCompetitions')).toContain('Archived 1 competition(s)');
-        expect(getTaskResult(response, 'archiveCompetitions')).toContain('0/1 push notifications sent');
-        expect(getTaskWarning(response, 'archiveCompetitions')).toContain('1 push notification(s) failed to deliver');
+        expect(getTaskWarning(response, 'archiveCompetitions')).toBeUndefined();
 
         const competition = await TestSQL.getCompetition({ competitionId });
         expect(competition[0].state).toBe(CompetitionState.Archived);
+    });
+});
+
+describe('performDailyTasks - sendCompetitionNotifications', () => {
+    // Helpers -----------------------------------------------------------------
+
+    // A competition whose end_date is the calendar day of `currentDate` is "ended"
+    // (its midnight-UTC end_date is before currentDate) but not yet old enough to
+    // archive (< 24h in processing), so it stays in whatever state we created it in.
+    function recentlyEndedDate(currentDateIso: string): Date {
+        return new Date(currentDateIso.slice(0, 10) + 'T00:00:00.000Z');
+    }
+
+    async function createNotificationCompetition(opts: {
+        currentDateIso: string;
+        state: CompetitionState;
+        ianaTimezone?: string;
+    }): Promise<string> {
+        const competitionId = crypto.randomUUID();
+        const endDate = recentlyEndedDate(opts.currentDateIso);
+        await TestSQL.createCompetitionWithState({
+            competitionId,
+            displayName: 'Notification Competition',
+            startDate: new Date(endDate.getTime() - 7 * 24 * 60 * 60 * 1000),
+            endDate,
+            adminUserId: convertUserIdToBuffer(testUserId1),
+            accessToken: 'test-token-' + competitionId.slice(0, 8),
+            ianaTimezone: opts.ianaTimezone ?? 'UTC',
+            state: opts.state
+        });
+        competitionsToCleanup.push(competitionId);
+        return competitionId;
+    }
+
+    async function addMember(competitionId: string, userId: string, opts?: { withToken?: boolean; timezone?: string; finalPoints?: number }) {
+        await TestSQL.addUserToCompetition({ userId: convertUserIdToBuffer(userId), competitionId });
+        if (opts?.withToken !== false) {
+            await TestSQL.createPushToken({
+                userId: convertUserIdToBuffer(userId),
+                pushToken: 'tok-' + userId + '-' + competitionId.slice(0, 8),
+                platform: 1,
+                appInstallId: crypto.randomUUID()
+            });
+        }
+        if (opts?.timezone) {
+            await TestSQL.setUserPreferredTimezone({ userId: convertUserIdToBuffer(userId), preferredTimezone: opts.timezone });
+        }
+        if (opts?.finalPoints !== undefined) {
+            await TestSQL.updateUserCompetitionFinalPoints({ userId: convertUserIdToBuffer(userId), competitionId, finalPoints: opts.finalPoints });
+        }
+    }
+
+    async function memberFlags(competitionId: string, userId: string) {
+        const rows = await TestSQL.getUsersInCompetition({ competitionId });
+        const buf = convertUserIdToBuffer(userId);
+        return rows.find(r => r.user_id.equals(buf))!;
+    }
+
+    // Mid-morning (08:30) and pre-dawn (02:00) instants in UTC
+    const inWindowUtc = '2026-06-15T08:30:00.000Z';
+    const outOfWindowUtc = '2026-06-15T02:00:00.000Z';
+
+    // Tests -------------------------------------------------------------------
+
+    test('sends the processing notification within the local morning window and marks the flag', async () => {
+        const competitionId = await createNotificationCompetition({ currentDateIso: inWindowUtc, state: CompetitionState.ProcessingResults });
+        await addMember(competitionId, testUserId1);
+
+        const response = await RequestUtilities.makeAdminPostRequest('admin/performDailyTasks', { currentDate: inWindowUtc });
+        expect(response.data.errors).toHaveLength(0);
+
+        const flags = await memberFlags(competitionId, testUserId1);
+        expect(flags.sent_processing_notification).toBe(true);
+        expect(flags.sent_complete_notification).toBe(false);
+    });
+
+    test('does not send outside the local morning window', async () => {
+        const competitionId = await createNotificationCompetition({ currentDateIso: outOfWindowUtc, state: CompetitionState.ProcessingResults });
+        await addMember(competitionId, testUserId1);
+
+        const response = await RequestUtilities.makeAdminPostRequest('admin/performDailyTasks', { currentDate: outOfWindowUtc });
+        expect(response.data.errors).toHaveLength(0);
+
+        const flags = await memberFlags(competitionId, testUserId1);
+        expect(flags.sent_processing_notification).toBe(false);
+    });
+
+    test('respects each member\'s own timezone in the same run', async () => {
+        // 23:30 UTC = 08:30 next day in Tokyo (+9, in window), 13:30 in Honolulu (-10, out of window)
+        const currentDate = '2026-06-15T23:30:00.000Z';
+        const competitionId = await createNotificationCompetition({ currentDateIso: currentDate, state: CompetitionState.ProcessingResults });
+        await addMember(competitionId, testUserId1, { timezone: 'Asia/Tokyo' });
+        await addMember(competitionId, testUserId2, { timezone: 'Pacific/Honolulu' });
+
+        const response = await RequestUtilities.makeAdminPostRequest('admin/performDailyTasks', { currentDate });
+        expect(response.data.errors).toHaveLength(0);
+
+        expect((await memberFlags(competitionId, testUserId1)).sent_processing_notification).toBe(true);
+        expect((await memberFlags(competitionId, testUserId2)).sent_processing_notification).toBe(false);
+    });
+
+    test('falls back to the competition timezone when a member has no preferred timezone', async () => {
+        // 13:30 UTC is out of the UTC morning window, but in-window for the competition's New York tz (09:30 EDT)
+        const currentDate = '2026-06-15T13:30:00.000Z';
+        const competitionId = await createNotificationCompetition({ currentDateIso: currentDate, state: CompetitionState.ProcessingResults, ianaTimezone: 'America/New_York' });
+        await addMember(competitionId, testUserId1); // no preferred timezone
+
+        const response = await RequestUtilities.makeAdminPostRequest('admin/performDailyTasks', { currentDate });
+        expect(response.data.errors).toHaveLength(0);
+
+        expect((await memberFlags(competitionId, testUserId1)).sent_processing_notification).toBe(true);
+    });
+
+    test('sends the results notification for an archived competition and marks both flags', async () => {
+        const competitionId = await createNotificationCompetition({ currentDateIso: inWindowUtc, state: CompetitionState.Archived });
+        await addMember(competitionId, testUserId1, { finalPoints: 500 });
+        await addMember(competitionId, testUserId2, { finalPoints: 300 });
+
+        const response = await RequestUtilities.makeAdminPostRequest('admin/performDailyTasks', { currentDate: inWindowUtc });
+        expect(response.data.errors).toHaveLength(0);
+
+        const flags1 = await memberFlags(competitionId, testUserId1);
+        expect(flags1.sent_complete_notification).toBe(true);
+        expect(flags1.sent_processing_notification).toBe(true); // completing makes processing moot
+        const flags2 = await memberFlags(competitionId, testUserId2);
+        expect(flags2.sent_complete_notification).toBe(true);
+    });
+
+    test('skips the processing notification once the competition has archived (catch-up)', async () => {
+        // Member never received the processing notification, but the competition is already archived
+        const competitionId = await createNotificationCompetition({ currentDateIso: inWindowUtc, state: CompetitionState.Archived });
+        await addMember(competitionId, testUserId1, { finalPoints: 100 });
+        // sanity: both flags start false
+        expect((await memberFlags(competitionId, testUserId1)).sent_processing_notification).toBe(false);
+
+        const response = await RequestUtilities.makeAdminPostRequest('admin/performDailyTasks', { currentDate: inWindowUtc });
+        expect(response.data.errors).toHaveLength(0);
+
+        const flags = await memberFlags(competitionId, testUserId1);
+        expect(flags.sent_complete_notification).toBe(true);
+        expect(flags.sent_processing_notification).toBe(true);
+    });
+
+    test('does not mark the flag when delivery fails, so it retries next run', async () => {
+        const competitionId = await createNotificationCompetition({ currentDateIso: inWindowUtc, state: CompetitionState.ProcessingResults });
+        await addMember(competitionId, testUserId1, { withToken: false }); // no push token -> delivery fails
+
+        const response = await RequestUtilities.makeAdminPostRequest('admin/performDailyTasks', { currentDate: inWindowUtc });
+        expect(response.data.errors).toHaveLength(0);
+        expect(getTaskWarning(response, 'sendCompetitionNotifications')).toContain('not delivered');
+
+        expect((await memberFlags(competitionId, testUserId1)).sent_processing_notification).toBe(false);
+    });
+
+    test('does not notify bot users', async () => {
+        const botUserId = Math.random().toString().slice(2, 8);
+        await TestSQL.createBotUser({
+            userId: convertUserIdToBuffer(botUserId),
+            firstName: 'Bot',
+            maxActiveCompetitions: 1,
+            isPro: false,
+            createdDate: new Date()
+        });
+        usersToCleanup.push(botUserId);
+
+        const competitionId = await createNotificationCompetition({ currentDateIso: inWindowUtc, state: CompetitionState.ProcessingResults });
+        await addMember(competitionId, testUserId1);
+        await addMember(competitionId, botUserId);
+
+        const response = await RequestUtilities.makeAdminPostRequest('admin/performDailyTasks', { currentDate: inWindowUtc });
+        expect(response.data.errors).toHaveLength(0);
+
+        expect((await memberFlags(competitionId, testUserId1)).sent_processing_notification).toBe(true);
+        expect((await memberFlags(competitionId, botUserId)).sent_processing_notification).toBe(false);
+    });
+
+    test('does not re-send to a member already notified', async () => {
+        const competitionId = await createNotificationCompetition({ currentDateIso: inWindowUtc, state: CompetitionState.ProcessingResults });
+        await addMember(competitionId, testUserId1);
+        await TestSQL.setNotificationFlags({ userId: convertUserIdToBuffer(testUserId1), competitionId, sentProcessing: true, sentComplete: false });
+
+        const response = await RequestUtilities.makeAdminPostRequest('admin/performDailyTasks', { currentDate: inWindowUtc });
+        expect(response.data.errors).toHaveLength(0);
+        // The competition has no un-notified members, so nothing is sent
+        expect(getTaskResult(response, 'sendCompetitionNotifications')).toBe('No competition notifications to send');
+
+        const flags = await memberFlags(competitionId, testUserId1);
+        expect(flags.sent_processing_notification).toBe(true);
     });
 });
 

--- a/WebService/FitWithFriends/test/routes/competitions/createCompetition.test.ts
+++ b/WebService/FitWithFriends/test/routes/competitions/createCompetition.test.ts
@@ -43,9 +43,15 @@ afterEach(async () => {
 
 test('Create competition happy path', async () => {
     const now = new Date();
+    // Anchor the dates to noon UTC. start_date/end_date are stored in DATE columns
+    // (the time is dropped), so an instant near midnight UTC would land on different
+    // calendar days depending on the server/test timezone, making the day-of-month
+    // assertions below flaky. Noon UTC is the same calendar day across UTC and the
+    // US timezones the tests run in.
+    const startDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0));
     const competitionInfo = {
-        startDate: now,
-        endDate: new Date(now.getTime() + 1000 * 60 * 60 * 24 * 7), // 7 days from now
+        startDate: startDate,
+        endDate: new Date(startDate.getTime() + 1000 * 60 * 60 * 24 * 7), // 7 days from start
         displayName: 'Test Competition',
         ianaTimezone: 'America/New_York'
     };

--- a/WebService/FitWithFriends/test/routes/competitions/notificationsSeen.test.ts
+++ b/WebService/FitWithFriends/test/routes/competitions/notificationsSeen.test.ts
@@ -1,0 +1,74 @@
+import * as TestSQL from '../../testUtilities/sql/testQueries.queries';
+import * as RequestUtilities from '../../testUtilities/testRequestUtilities';
+import * as AuthUtilities from '../../testUtilities/testAuthUtilities';
+import { convertUserIdToBuffer } from '../../../utilities/userHelpers';
+import { CompetitionState } from '../../../utilities/enums/CompetitionState';
+
+/*
+    Tests for POST /competitions/:competitionId/notificationsSeen
+    The client calls this when it shows the end-of-competition screen so the server
+    does not also send the (now-redundant) push at the user's local 8am.
+*/
+
+const memberId = Math.random().toString().slice(2, 10);
+const nonMemberId = Math.random().toString().slice(2, 10);
+
+let competitionsToCleanup: string[] = [];
+
+beforeEach(async () => {
+    await TestSQL.createUser({ userId: convertUserIdToBuffer(memberId), firstName: 'Member', maxActiveCompetitions: 5, isPro: false, createdDate: new Date() });
+    await TestSQL.createUser({ userId: convertUserIdToBuffer(nonMemberId), firstName: 'NonMember', maxActiveCompetitions: 5, isPro: false, createdDate: new Date() });
+});
+
+afterEach(async () => {
+    await TestSQL.clearDataForUser({ userId: convertUserIdToBuffer(memberId) });
+    await TestSQL.clearDataForUser({ userId: convertUserIdToBuffer(nonMemberId) });
+    await Promise.all(competitionsToCleanup.map(competitionId => TestSQL.clearDataForCompetition({ competitionId })));
+    competitionsToCleanup = [];
+});
+
+async function createCompetitionWithMember(): Promise<string> {
+    const competitionId = crypto.randomUUID();
+    await TestSQL.createCompetitionWithState({
+        competitionId,
+        displayName: 'Seen Competition',
+        startDate: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000),
+        endDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        adminUserId: convertUserIdToBuffer(memberId),
+        accessToken: 'tok-' + competitionId.slice(0, 8),
+        ianaTimezone: 'America/New_York',
+        state: CompetitionState.Archived
+    });
+    competitionsToCleanup.push(competitionId);
+    await TestSQL.addUserToCompetition({ userId: convertUserIdToBuffer(memberId), competitionId });
+    return competitionId;
+}
+
+async function flagsFor(competitionId: string, userId: string) {
+    const rows = await TestSQL.getUsersInCompetition({ competitionId });
+    return rows.find(r => r.user_id.equals(convertUserIdToBuffer(userId)))!;
+}
+
+test('marks both notification flags for a member', async () => {
+    const competitionId = await createCompetitionWithMember();
+    const accessToken = await AuthUtilities.getAccessTokenForUser(memberId);
+
+    const response = await RequestUtilities.makePostRequest(`competitions/${competitionId}/notificationsSeen`, {}, accessToken);
+    expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 200 }));
+
+    const flags = await flagsFor(competitionId, memberId);
+    expect(flags.sent_complete_notification).toBe(true);
+    expect(flags.sent_processing_notification).toBe(true);
+});
+
+test('returns 401 for a non-member', async () => {
+    const competitionId = await createCompetitionWithMember();
+    const accessToken = await AuthUtilities.getAccessTokenForUser(nonMemberId);
+
+    const response = await RequestUtilities.makePostRequest(`competitions/${competitionId}/notificationsSeen`, {}, accessToken);
+    expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 401 }));
+
+    // The member's flags are untouched
+    const flags = await flagsFor(competitionId, memberId);
+    expect(flags.sent_complete_notification).toBe(false);
+});

--- a/WebService/FitWithFriends/test/routes/users.test.ts
+++ b/WebService/FitWithFriends/test/routes/users.test.ts
@@ -110,6 +110,78 @@ test('userFromAppleID lastName too long', async () => {
     expect(response.data.context).toContain('Parameter too long');
 });
 
+test('userFromAppleID stores a valid preferred timezone', async () => {
+    const response = await RequestUtilities.makePostRequest('users/userFromAppleID', {
+        userId: appleUserId,
+        firstName: 'Test',
+        lastName: 'User',
+        idToken: 'some_token',
+        timezone: 'America/Los_Angeles'
+    });
+
+    expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 200 }));
+    const user = await TestSQL.getUser({ userId: convertUserIdToBuffer(expectedUserId) });
+    expect(user[0].preferred_timezone).toBe('America/Los_Angeles');
+});
+
+test('userFromAppleID ignores an invalid timezone (stores null)', async () => {
+    const response = await RequestUtilities.makePostRequest('users/userFromAppleID', {
+        userId: appleUserId,
+        firstName: 'Test',
+        lastName: 'User',
+        idToken: 'some_token',
+        timezone: 'Not/AZone'
+    });
+
+    expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 200 }));
+    const user = await TestSQL.getUser({ userId: convertUserIdToBuffer(expectedUserId) });
+    expect(user[0].preferred_timezone).toBeNull();
+});
+
+// MARK: - POST /users/timezone
+
+describe('POST /users/timezone', () => {
+    const testUserId = Math.random().toString().slice(2, 10);
+    const userIdBuffer = convertUserIdToBuffer(testUserId);
+
+    beforeEach(async () => {
+        await TestSQL.createUser({
+            userId: userIdBuffer,
+            firstName: 'Tz',
+            maxActiveCompetitions: 1,
+            isPro: false,
+            createdDate: new Date()
+        });
+    });
+
+    afterEach(async () => {
+        await TestSQL.clearDataForUser({ userId: userIdBuffer });
+    });
+
+    test('happy path - updates the preferred timezone', async () => {
+        const accessToken = await AuthUtilities.getAccessTokenForUser(testUserId);
+        const response = await RequestUtilities.makePostRequest('users/timezone', { timezone: 'Asia/Tokyo' }, accessToken);
+
+        expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 200 }));
+        const user = await TestSQL.getUser({ userId: userIdBuffer });
+        expect(user[0].preferred_timezone).toBe('Asia/Tokyo');
+    });
+
+    test('rejects an invalid timezone with 400', async () => {
+        const accessToken = await AuthUtilities.getAccessTokenForUser(testUserId);
+        const response = await RequestUtilities.makePostRequest('users/timezone', { timezone: 'Mars/Phobos' }, accessToken);
+
+        expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 400 }));
+        const user = await TestSQL.getUser({ userId: userIdBuffer });
+        expect(user[0].preferred_timezone).toBeNull();
+    });
+
+    test('unauthenticated - returns 400', async () => {
+        const response = await RequestUtilities.makePostRequest('users/timezone', { timezone: 'Asia/Tokyo' });
+        expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 400 }));
+    });
+});
+
 // MARK: - DELETE /users/me
 
 describe('DELETE /users/me', () => {

--- a/WebService/FitWithFriends/test/testUtilities/sql/testQueries.queries.ts
+++ b/WebService/FitWithFriends/test/testUtilities/sql/testQueries.queries.ts
@@ -178,6 +178,7 @@ export interface IGetUserResult {
   is_pro: boolean;
   last_name: string | null;
   max_active_competitions: number;
+  preferred_timezone: string | null;
   subscription_expires_date: Date | null;
   user_id: Buffer;
 }
@@ -451,13 +452,13 @@ export interface IUpdateUserCompetitionFinalPointsQuery {
   result: IUpdateUserCompetitionFinalPointsResult;
 }
 
-const updateUserCompetitionFinalPointsIR: any = {"usedParamSet":{"finalPoints":true,"userId":true,"competitionId":true},"params":[{"name":"finalPoints","required":true,"transform":{"type":"scalar"},"locs":[{"a":46,"b":58}]},{"name":"userId","required":true,"transform":{"type":"scalar"},"locs":[{"a":77,"b":84}]},{"name":"competitionId","required":true,"transform":{"type":"scalar"},"locs":[{"a":107,"b":121}]}],"statement":"UPDATE users_competitions \nSET final_points = :finalPoints! \nWHERE user_id = :userId! AND competition_id = :competitionId!"};
+const updateUserCompetitionFinalPointsIR: any = {"usedParamSet":{"finalPoints":true,"userId":true,"competitionId":true},"params":[{"name":"finalPoints","required":true,"transform":{"type":"scalar"},"locs":[{"a":45,"b":57}]},{"name":"userId","required":true,"transform":{"type":"scalar"},"locs":[{"a":75,"b":82}]},{"name":"competitionId","required":true,"transform":{"type":"scalar"},"locs":[{"a":105,"b":119}]}],"statement":"UPDATE users_competitions\nSET final_points = :finalPoints!\nWHERE user_id = :userId! AND competition_id = :competitionId!"};
 
 /**
  * Query generated from SQL:
  * ```
- * UPDATE users_competitions 
- * SET final_points = :finalPoints! 
+ * UPDATE users_competitions
+ * SET final_points = :finalPoints!
  * WHERE user_id = :userId! AND competition_id = :competitionId!
  * ```
  */
@@ -465,6 +466,72 @@ export function updateUserCompetitionFinalPoints(params: IUpdateUserCompetitionF
   return import('@pgtyped/runtime').then(pgtyped => {
     const updateUserCompetitionFinalPoints = new pgtyped.PreparedQuery<IUpdateUserCompetitionFinalPointsParams,IUpdateUserCompetitionFinalPointsResult>(updateUserCompetitionFinalPointsIR);
     return updateUserCompetitionFinalPoints.run(params, DatabaseConnectionPool);
+  });
+}
+
+
+/** 'SetUserPreferredTimezone' parameters type */
+export interface ISetUserPreferredTimezoneParams {
+  preferredTimezone?: string | null | void;
+  userId: Buffer;
+}
+
+/** 'SetUserPreferredTimezone' return type */
+export type ISetUserPreferredTimezoneResult = void;
+
+/** 'SetUserPreferredTimezone' query type */
+export interface ISetUserPreferredTimezoneQuery {
+  params: ISetUserPreferredTimezoneParams;
+  result: ISetUserPreferredTimezoneResult;
+}
+
+const setUserPreferredTimezoneIR: any = {"usedParamSet":{"preferredTimezone":true,"userId":true},"params":[{"name":"preferredTimezone","required":false,"transform":{"type":"scalar"},"locs":[{"a":38,"b":55}]},{"name":"userId","required":true,"transform":{"type":"scalar"},"locs":[{"a":73,"b":80}]}],"statement":"UPDATE users SET preferred_timezone = :preferredTimezone WHERE user_id = :userId!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE users SET preferred_timezone = :preferredTimezone WHERE user_id = :userId!
+ * ```
+ */
+export function setUserPreferredTimezone(params: ISetUserPreferredTimezoneParams): Promise<Array<ISetUserPreferredTimezoneResult>> {
+  return import('@pgtyped/runtime').then(pgtyped => {
+    const setUserPreferredTimezone = new pgtyped.PreparedQuery<ISetUserPreferredTimezoneParams,ISetUserPreferredTimezoneResult>(setUserPreferredTimezoneIR);
+    return setUserPreferredTimezone.run(params, DatabaseConnectionPool);
+  });
+}
+
+
+/** 'SetNotificationFlags' parameters type */
+export interface ISetNotificationFlagsParams {
+  competitionId: string;
+  sentComplete: boolean;
+  sentProcessing: boolean;
+  userId: Buffer;
+}
+
+/** 'SetNotificationFlags' return type */
+export type ISetNotificationFlagsResult = void;
+
+/** 'SetNotificationFlags' query type */
+export interface ISetNotificationFlagsQuery {
+  params: ISetNotificationFlagsParams;
+  result: ISetNotificationFlagsResult;
+}
+
+const setNotificationFlagsIR: any = {"usedParamSet":{"sentProcessing":true,"sentComplete":true,"userId":true,"competitionId":true},"params":[{"name":"sentProcessing","required":true,"transform":{"type":"scalar"},"locs":[{"a":61,"b":76}]},{"name":"sentComplete","required":true,"transform":{"type":"scalar"},"locs":[{"a":108,"b":121}]},{"name":"userId","required":true,"transform":{"type":"scalar"},"locs":[{"a":139,"b":146}]},{"name":"competitionId","required":true,"transform":{"type":"scalar"},"locs":[{"a":169,"b":183}]}],"statement":"UPDATE users_competitions\nSET sent_processing_notification = :sentProcessing!, sent_complete_notification = :sentComplete!\nWHERE user_id = :userId! AND competition_id = :competitionId!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE users_competitions
+ * SET sent_processing_notification = :sentProcessing!, sent_complete_notification = :sentComplete!
+ * WHERE user_id = :userId! AND competition_id = :competitionId!
+ * ```
+ */
+export function setNotificationFlags(params: ISetNotificationFlagsParams): Promise<Array<ISetNotificationFlagsResult>> {
+  return import('@pgtyped/runtime').then(pgtyped => {
+    const setNotificationFlags = new pgtyped.PreparedQuery<ISetNotificationFlagsParams,ISetNotificationFlagsResult>(setNotificationFlagsIR);
+    return setNotificationFlags.run(params, DatabaseConnectionPool);
   });
 }
 
@@ -519,6 +586,8 @@ export interface IGetUsersInCompetitionParams {
 export interface IGetUsersInCompetitionResult {
   competition_id: string;
   final_points: number | null;
+  sent_complete_notification: boolean;
+  sent_processing_notification: boolean;
   user_id: Buffer;
 }
 

--- a/WebService/FitWithFriends/test/testUtilities/sql/testQueries.sql
+++ b/WebService/FitWithFriends/test/testUtilities/sql/testQueries.sql
@@ -45,8 +45,16 @@ INSERT INTO users_competitions (user_id, competition_id)
 VALUES (:userId!, :competitionId!);
 
 /* @name UpdateUserCompetitionFinalPoints */
-UPDATE users_competitions 
-SET final_points = :finalPoints! 
+UPDATE users_competitions
+SET final_points = :finalPoints!
+WHERE user_id = :userId! AND competition_id = :competitionId!;
+
+/* @name SetUserPreferredTimezone */
+UPDATE users SET preferred_timezone = :preferredTimezone WHERE user_id = :userId!;
+
+/* @name SetNotificationFlags */
+UPDATE users_competitions
+SET sent_processing_notification = :sentProcessing!, sent_complete_notification = :sentComplete!
 WHERE user_id = :userId! AND competition_id = :competitionId!;
 
 /* @name GetCompetition */

--- a/WebService/FitWithFriends/utilities/apnsHelper.ts
+++ b/WebService/FitWithFriends/utilities/apnsHelper.ts
@@ -16,6 +16,10 @@ export interface SendResult {
     sent: number;
     failed: number;
     failures: Array<{ userId: string; reason: string }>;
+    // User IDs for which at least one device was successfully delivered to.
+    // Callers use this to mark a per-user notification as delivered — a user
+    // with multiple devices counts as delivered if any one device succeeded.
+    succeededUserIds: string[];
 }
 
 // Cache the token and its expiry to avoid re-signing on every request.
@@ -26,14 +30,14 @@ let cachedTokenExpiresAt: number = 0;
 export async function sendPushNotifications(notifications: Notification[]): Promise<SendResult> {
     if (notifications.length === 0) {
         console.log('No notifications to send');
-        return { sent: 0, failed: 0, failures: [] };
+        return { sent: 0, failed: 0, failures: [], succeededUserIds: [] };
     }
 
     // Get distinct user IDs from notifications
     const userIds = Array.from(new Set(notifications.map(n => n.userId)));
     if (userIds.length === 0) {
         console.log('No distinct user IDs found in notifications');
-        return { sent: 0, failed: 0, failures: [] };
+        return { sent: 0, failed: 0, failures: [], succeededUserIds: [] };
     }
 
     const [pushTokenResults, apnsToken] = await Promise.all([
@@ -49,6 +53,7 @@ export async function sendPushNotifications(notifications: Notification[]): Prom
     let sent = 0;
     let failed = 0;
     const failures: Array<{ userId: string; reason: string }> = [];
+    const succeededUserIds = new Set<string>();
     const notificationTokenPairs: Array<{
         userId: string;
         pushToken: string;
@@ -84,6 +89,7 @@ export async function sendPushNotifications(notifications: Notification[]): Prom
         for (let j = 0; j < results.length; j++) {
             if (results[j].delivered) {
                 sent++;
+                succeededUserIds.add(batch[j].userId);
             } else {
                 failed++;
                 failures.push({ userId: batch[j].userId, reason: results[j].reason });
@@ -91,7 +97,7 @@ export async function sendPushNotifications(notifications: Notification[]): Prom
         }
     }
 
-    return { sent, failed, failures };
+    return { sent, failed, failures, succeededUserIds: Array.from(succeededUserIds) };
 }
 
 async function getPushTokenForUser(userId: string): Promise<{ userId: string, tokens: string[] }> {

--- a/WebService/FitWithFriends/utilities/timezoneHelpers.ts
+++ b/WebService/FitWithFriends/utilities/timezoneHelpers.ts
@@ -1,0 +1,40 @@
+'use strict';
+
+// Whether the given string is an IANA timezone the runtime can resolve. Used to
+// validate client-reported timezones before storing them, and as a guard before
+// scheduling notifications so a bad value can't crash the daily task.
+export function isValidTimeZone(timeZone: string): boolean {
+    try {
+        new Intl.DateTimeFormat('en-US', { timeZone });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// Returns the hour-of-day (0-23) at the given instant in the given IANA timezone.
+// Uses hourCycle 'h23' so midnight is 0 (not 24) and the result is always 0-23.
+export function getLocalHour(date: Date, timeZone: string): number {
+    const hourStr = new Intl.DateTimeFormat('en-US', {
+        hour: '2-digit',
+        hourCycle: 'h23',
+        timeZone
+    }).format(date);
+    return parseInt(hourStr, 10);
+}
+
+// The morning window (local time) during which end-of-competition notifications
+// are delivered. Sending only within a window — rather than "any time after 8am" —
+// guarantees a morning delivery: if a competition changes state during the user's
+// evening/night, the notification waits for the next morning instead of firing late.
+// The window also gives the hourly cron several retry attempts (e.g. for APNs
+// throttling) before the morning passes.
+export const NOTIFICATION_START_HOUR = 8;
+export const NOTIFICATION_END_HOUR = 12;
+
+// Whether it is currently within the morning notification window in the given
+// timezone — i.e. whether an end-of-competition notification may be sent now.
+export function isWithinNotificationWindow(date: Date, timeZone: string): boolean {
+    const hour = getLocalHour(date, timeZone);
+    return hour >= NOTIFICATION_START_HOUR && hour < NOTIFICATION_END_HOUR;
+}

--- a/WebService/migrations/003_add_per_user_notification_timing.sql
+++ b/WebService/migrations/003_add_per_user_notification_timing.sql
@@ -16,3 +16,29 @@ ALTER TABLE public.users ADD COLUMN preferred_timezone text;
 ALTER TABLE public.users_competitions
     ADD COLUMN sent_processing_notification boolean NOT NULL DEFAULT false,
     ADD COLUMN sent_complete_notification boolean NOT NULL DEFAULT false;
+
+-- Backfill for the cutover: competitions that already transitioned under the old
+-- code path were notified at the state transition (around midnight UTC). Mark
+-- those notifications as already-satisfied so the new per-user pass — which would
+-- otherwise pick up any state 2/3 competition that ended within the last few days
+-- with false flags — does not re-send them and double-notify users.
+--
+-- State values: 1 = NotStartedOrActive, 2 = ProcessingResults, 3 = Archived.
+
+-- The "processing" notification was sent at the active -> processing transition,
+-- so it has already happened for anything past the active state.
+UPDATE public.users_competitions uc
+SET sent_processing_notification = true
+FROM public.competitions c
+WHERE uc.competition_id = c.competition_id
+  AND c.state IN (2, 3);
+
+-- The "final results" notification was sent at archival, so it has already
+-- happened only for archived competitions. Competitions still in the processing
+-- state intentionally keep sent_complete_notification = false so the new per-user
+-- pass delivers their results notification (once) when they archive.
+UPDATE public.users_competitions uc
+SET sent_complete_notification = true
+FROM public.competitions c
+WHERE uc.competition_id = c.competition_id
+  AND c.state = 3;

--- a/WebService/migrations/003_add_per_user_notification_timing.sql
+++ b/WebService/migrations/003_add_per_user_notification_timing.sql
@@ -1,0 +1,18 @@
+-- Migration: Per-user competition notification timing
+-- Date: 2026-05-31
+
+-- The user's preferred IANA timezone, reported by the client. Used to send the
+-- competition "processing" and "final results" push notifications at ~8am local
+-- time per user. NULL = unknown (e.g. client hasn't reported yet); callers fall
+-- back to the competition's iana_timezone.
+ALTER TABLE public.users ADD COLUMN preferred_timezone text;
+
+-- Per-(user, competition) delivery tracking for the two end-of-competition
+-- notifications. A flag is set true once the notification has been satisfied —
+-- either successfully delivered via APNs, or rendered in-app (the client marks
+-- it seen when it shows the end-of-competition screen). This decouples the
+-- notification from the single competition state transition so each user can be
+-- notified at their own local 8am.
+ALTER TABLE public.users_competitions
+    ADD COLUMN sent_processing_notification boolean NOT NULL DEFAULT false,
+    ADD COLUMN sent_complete_notification boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## What

Competition **processing** and **final results** push notifications now fire at **~8am local time per user** instead of around midnight UTC. A member in New York and one in California each get notified at their own 8am.

## Why

Previously both notifications were sent by the single competition state transition in the hourly daily-tasks cron, which fired around midnight UTC for everyone regardless of where they live.

## How

The state transitions stay on their existing schedule (and still freeze `final_points` at archival), but the **notification sends are decoupled into a new per-user pass**. Each member is notified once, during their **local 8am–noon window** (their reported timezone, falling back to the competition's). Delivery is tracked per `(user, competition)` via two new `sent_*` flags; only members we actually delivered to are marked, so failed/throttled sends retry on the next hourly run. Seeing the results in-app also satisfies the flags (the client marks them), so the push is a fallback for members who haven't opened the app.

### Backend
- **Migration 003** (+ `CreateDatabaseTables.sql`): `users.preferred_timezone`, and `users_competitions.sent_processing_notification` / `sent_complete_notification`.
- `routes/admin.ts`: new `sendDueCompetitionNotifications` pass — morning-window gating, ranks results from frozen `final_points`, excludes bots, drops the processing notification once archived, marks only delivered users. `processesRecentlyEndedCompetitions` / `archiveCompetitions` now only transition state.
- `utilities/apnsHelper.ts`: `SendResult` reports `succeededUserIds` so the caller can mark on delivery (a multi-device user counts as delivered if any device succeeds).
- New endpoints: `POST /users/timezone` and `POST /competitions/:competitionId/notificationsSeen`.
- New `utilities/timezoneHelpers.ts` (`getLocalHour` / `isWithinNotificationWindow` / `isValidTimeZone`).

### iOS
- Reports `TimeZone.current.identifier` on every foreground (`HomepageViewModel.refreshData`), so notifications track the user's current location.
- Marks notifications seen when the end-of-competition celebration screen is shown (`CompetitionEndAlertViewModel`), suppressing the redundant push. The celebration still appears on archival (any time of day); the push is the 8am fallback.

## Reviewer notes
- **No infra change** — the cron is already hourly; only the gating logic changed.
- The `.queries.ts` files were regenerated with the local pgtyped fork.
- Clients with no reported timezone yet (older app versions) gracefully fall back to the competition timezone.
- Also de-flakes the `createCompetition` happy-path date assertion by anchoring the test dates to noon UTC (a `date`-column round-trip was timezone/midnight-boundary sensitive).

## Testing
- Backend: full suite green (295/295). New coverage for the notification pass (window gating, per-user timezone, competition-tz fallback, results ranking, archived catch-up, retry-on-failure, bot exclusion, no-resend) and both new endpoints.
- iOS: app and watch app build; new `CompetitionEndAlertViewModel` tests for the mark-seen behavior pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)