### PR TITLE
Redesign competitions UX: grouped home feed, completed states, scoring rules sheet

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Model/Competitions/CompetitionOverview.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Model/Competitions/CompetitionOverview.swift
@@ -64,6 +64,31 @@ public class CompetitionOverview: IdentifiableBase, Codable, Comparable {
         return hasCompetitionStarted && !hasCompetitionEnded
     }
 
+    /// Home-feed grouping bucket derived purely from the competition dates.
+    /// - Active: `now >= startDate && now < endDate`
+    /// - Upcoming: `now < startDate`
+    /// - Completed: `now >= endDate`
+    enum Bucket {
+        case active
+        case upcoming
+        case completed
+    }
+
+    var bucket: Bucket {
+        if !hasCompetitionStarted { return .upcoming }
+        if hasCompetitionEnded { return .completed }
+        return .active
+    }
+
+    /// The current user's final 1-based placement among all participants, or `nil`
+    /// when the user isn't in the results. Uses the same ordering as the leaderboard.
+    func finalPlacement(for userId: String?) -> Int? {
+        guard let userId else { return nil }
+        let sorted = currentResults.sorted()
+        guard let idx = sorted.firstIndex(where: { $0.userId == userId }) else { return nil }
+        return idx + 1
+    }
+
     /// This init is used for testing and mock data. Production code will decode the entity from JSON
     init(id: UUID = UUID(), name: String = "Test Competition", start: Date = Date(), end: Date = Date(), currentResults: [UserCompetitionPoints] = [], isUserAdmin: Bool = false, competitionState: CompetitionState = .notStartedOrActive, isPublic: Bool = false, scoringRules: ScoringRules = .default, scoringUnit: ScoringUnit? = nil) {
         competitionId = id

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionDetailView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionDetailView.swift
@@ -17,6 +17,9 @@ struct CompetitionDetailView: View {
     @State private var actionInProgress = false
     @State private var shouldShowShareSheet = false
     @State private var shareUrl: URL?
+    @State private var showScoringRules = false
+
+    @StateObject private var recapViewModel: CompetitionRecapViewModel
 
     init(competitionOverview: CompetitionOverview,
          homepageSheetViewModel: HomepageSheetViewModel,
@@ -26,6 +29,15 @@ struct CompetitionDetailView: View {
         self.objectGraph = objectGraph
         viewModel = CompetitionDetailViewModel(competitionManager: objectGraph.competitionManager,
                                                homepageSheetViewModel: homepageSheetViewModel)
+        _recapViewModel = StateObject(wrappedValue: CompetitionRecapViewModel(competitionManager: objectGraph.competitionManager))
+    }
+
+    private var isCompleted: Bool {
+        competitionOverview.bucket == .completed
+    }
+
+    private var loggedInUserId: String? {
+        objectGraph.authenticationManager.loggedInUserId
     }
 
     var body: some View {
@@ -44,18 +56,41 @@ struct CompetitionDetailView: View {
                     VStack(spacing: 16) {
                         Spacer().frame(height: 56)  // room for floating chrome
 
-                        CompetitionDetailHeaderView(competitionOverview: competitionOverview)
+                        CompetitionDetailHeaderView(competitionOverview: competitionOverview,
+                                                    isCompleted: isCompleted,
+                                                    onShowScoringRules: { showScoringRules = true })
                             .padding(.horizontal, 20)
 
-                        CompetitionStandingCard(competitionOverview: competitionOverview,
-                                                loggedInUserId: objectGraph.authenticationManager.loggedInUserId)
-                            .padding(.horizontal, 16)
+                        if isCompleted {
+                            CompetitionResultCard(competitionOverview: competitionOverview,
+                                                  loggedInUserId: loggedInUserId)
+                                .padding(.horizontal, 16)
+
+                            CompetitionRecapGrid(scoringRules: competitionOverview.scoringRules,
+                                                 scoringUnit: competitionOverview.scoringUnit,
+                                                 stats: recapViewModel.stats)
+                                .padding(.horizontal, 16)
+                        } else {
+                            CompetitionStandingCard(competitionOverview: competitionOverview,
+                                                    loggedInUserId: loggedInUserId)
+                                .padding(.horizontal, 16)
+                        }
 
                         // Leaderboard
                         VStack(spacing: 10) {
+                            if isCompleted {
+                                HStack {
+                                    Text("Final standings")
+                                        .font(.system(size: 17, weight: .semibold))
+                                        .foregroundStyle(Color("Ink"))
+                                    Spacer()
+                                }
+                                .padding(.horizontal, 4)
+                            }
+
                             ForEach(Array(sortedResults.enumerated()), id: \.offset) { index, points in
                                 let position = UserPosition(userCompetitionPoints: points, position: UInt(index + 1))
-                                let isCurrentUser = points.userId == objectGraph.authenticationManager.loggedInUserId
+                                let isCurrentUser = points.userId == loggedInUserId
 
                                 NavigationLink {
                                     UserCompetitionDailyDetailsView(
@@ -78,6 +113,12 @@ struct CompetitionDetailView: View {
                         .accessibilityElement(children: .contain)
                         .accessibilityIdentifier("competitionLeaderboard")
 
+                        if isCompleted {
+                            completedCtaStack
+                                .padding(.horizontal, 16)
+                                .padding(.top, 4)
+                        }
+
                         Spacer().frame(height: 24)
                     }
                 }
@@ -88,10 +129,44 @@ struct CompetitionDetailView: View {
             }
             .navigationBarHidden(true)
             .presentationDragIndicator(.visible)
+            .task {
+                guard isCompleted else { return }
+                let finalTotal = competitionOverview.currentResults
+                    .first(where: { $0.userId == loggedInUserId })?.totalPoints ?? 0
+                await recapViewModel.loadIfNeeded(competitionId: competitionOverview.competitionId,
+                                                  userId: loggedInUserId,
+                                                  finalTotal: finalTotal)
+            }
             .sheet(isPresented: $shouldShowShareSheet) {
                 if let shareUrl {
                     ShareSheet(url: shareUrl)
                 }
+            }
+            .sheet(isPresented: $showScoringRules) {
+                ScoringRulesSheet(competitionOverview: competitionOverview)
+            }
+        }
+    }
+
+    // MARK: - Completed CTA stack
+
+    private var didWin: Bool {
+        competitionOverview.finalPlacement(for: loggedInUserId) == 1
+    }
+
+    private var completedCtaStack: some View {
+        VStack(spacing: 10) {
+            FWFPrimaryButton(didWin ? "Defend your title" : "Demand a rematch", icon: "trophy") {
+                // Dismiss the detail sheet, then present the create wizard — mirrors
+                // the rematch behavior in CompetitionEndView.
+                dismiss()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                    homepageSheetViewModel.updateState(sheet: .createCompetition, state: true)
+                }
+            }
+
+            FWFSecondaryButton(didWin ? "Share your win" : "Share recap", icon: "square.and.arrow.up") {
+                shareCompetition()
             }
         }
     }
@@ -192,6 +267,10 @@ struct CompetitionDetailView: View {
 
 struct CompetitionDetailHeaderView: View {
     let competitionOverview: CompetitionOverview
+    /// When `true`, the meta row shows an "Ended {date}" badge instead of "N days left".
+    var isCompleted: Bool = false
+    /// Invoked when the user taps the scoring chip or the ? help button.
+    var onShowScoringRules: (() -> Void)? = nil
 
     private var daysLeft: Int {
         let seconds = competitionOverview.endDate.timeIntervalSince(Date())
@@ -206,49 +285,76 @@ struct CompetitionDetailHeaderView: View {
         return "\(start) → \(end)"
     }
 
-    private var scoringChipLabel: String {
-        CompetitionOverviewViewModel.scoringChip(for: competitionOverview.scoringRules).label
+    private var scoringChip: CompetitionOverviewViewModel.ScoringChip {
+        CompetitionOverviewViewModel.scoringChip(for: competitionOverview.scoringRules)
+    }
+
+    private var memberNoun: String {
+        competitionOverview.isPublic ? "members" : "friends"
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // Visibility chip
-            HStack(spacing: 4) {
-                Image(systemName: competitionOverview.isPublic ? "globe" : "lock.fill")
-                    .font(.system(size: 10, weight: .semibold))
-                Text(competitionOverview.isPublic ? "Public" : "Private")
-                    .font(.system(size: 10.5, weight: .semibold))
-                    .tracking(0.6)
-                Text("·")
-                Text("\(competitionOverview.currentResults.count) friends")
-                    .font(.system(size: 10.5, weight: .semibold))
-                    .tracking(0.6)
+            // Chips row — visibility + tappable scoring chip
+            HStack(spacing: 8) {
+                visibilityChip
+                Button {
+                    onShowScoringRules?()
+                } label: {
+                    scoringChipView
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("scoringChip")
+                .disabled(onShowScoringRules == nil)
             }
-            .foregroundStyle(competitionOverview.isPublic ? Color("Brand") : Color("InkMute"))
-            .padding(.horizontal, 10)
-            .padding(.vertical, 4)
-            .background(
-                Capsule().fill(competitionOverview.isPublic ? Color("BrandSoft") : Color("SurfaceAlt"))
-            )
 
-            // Competition name (editorial serif)
-            Text(competitionOverview.competitionName)
-                .font(.system(size: 32, weight: .regular, design: .serif))
-                .foregroundStyle(Color("Ink"))
-                .tracking(-0.02 * 32)
-                .lineSpacing(-32 * 0.05)
-                .fixedSize(horizontal: false, vertical: true)
+            // Name + ? help button
+            HStack(alignment: .top, spacing: 8) {
+                Text(competitionOverview.competitionName)
+                    .font(.system(size: 31, weight: .regular, design: .serif))
+                    .foregroundStyle(Color("Ink"))
+                    .tracking(-0.02 * 31)
+                    .lineSpacing(-31 * 0.05)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Meta row — date range · scoring rule · days left
+                if onShowScoringRules != nil {
+                    Button {
+                        onShowScoringRules?()
+                    } label: {
+                        Image(systemName: "questionmark")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(Color("Brand"))
+                            .frame(width: 34, height: 34)
+                            .background(Circle().fill(Color("BrandSoft")))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("How scoring works")
+                    .accessibilityIdentifier("scoringRulesButton")
+                    .padding(.top, 4)
+                }
+            }
+
+            // Meta row — date range · scoring rule · (days left | Ended date)
             HStack(spacing: 8) {
                 Text(dateRangeText)
                     .font(.system(size: 13))
                     .foregroundStyle(Color("InkSoft"))
                 metaDot
-                Text(scoringChipLabel)
+                Text(scoringChip.label)
                     .font(.system(size: 13))
                     .foregroundStyle(Color("InkSoft"))
-                if daysLeft > 0 {
+                if isCompleted {
+                    metaDot
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Color("InkFaint"))
+                        Text("Ended \(MedalPalette.shortMonthDay(competitionOverview.endDate))")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(Color("InkMute"))
+                    }
+                } else if daysLeft > 0 {
                     metaDot
                     Text("\(daysLeft) days left")
                         .font(.system(size: 13, weight: daysLeft <= 7 ? .semibold : .regular))
@@ -256,6 +362,40 @@ struct CompetitionDetailHeaderView: View {
                 }
             }
         }
+    }
+
+    private var visibilityChip: some View {
+        HStack(spacing: 4) {
+            Image(systemName: competitionOverview.isPublic ? "globe" : "lock.fill")
+                .font(.system(size: 10, weight: .semibold))
+            Text(competitionOverview.isPublic ? "Public" : "Private")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.6)
+            Text("·")
+            Text("\(competitionOverview.currentResults.count) \(memberNoun)")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.6)
+        }
+        .foregroundStyle(competitionOverview.isPublic ? Color("Brand") : Color("InkMute"))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(
+            Capsule().fill(competitionOverview.isPublic ? Color("BrandSoft") : Color("SurfaceAlt"))
+        )
+    }
+
+    private var scoringChipView: some View {
+        HStack(spacing: 4) {
+            Image(systemName: scoringChip.icon)
+                .font(.system(size: 10, weight: .semibold))
+            Text(scoringChip.label)
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.6)
+        }
+        .foregroundStyle(scoringChip.color)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(scoringChip.color.opacity(0.12)))
     }
 
     private var metaDot: some View {
@@ -417,6 +557,923 @@ struct CompetitionStandingCard: View {
     }
 }
 
+// MARK: - Mini podium
+
+/// Three-step podium rendered in 2-1-3 order. The current user's step gets a
+/// medal-colored ring around the avatar. Missing placements render a neutral
+/// step with a blank avatar well.
+struct MiniPodium: View {
+    struct Entry {
+        let rank: Int
+        let name: String
+        let isCurrentUser: Bool
+    }
+
+    /// Entries for whatever placements are present (ranks 1...3).
+    let entries: [Entry]
+    var scale: CGFloat = 1
+
+    private func entry(forRank rank: Int) -> Entry? {
+        entries.first { $0.rank == rank }
+    }
+
+    private func stepHeight(_ rank: Int) -> CGFloat {
+        switch rank {
+        case 1: return 46 * scale
+        case 2: return 34 * scale
+        default: return 26 * scale
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 6) {
+            step(rank: 2)
+            step(rank: 1)
+            step(rank: 3)
+        }
+    }
+
+    @ViewBuilder
+    private func step(rank: Int) -> some View {
+        let medal = MedalPalette.color(for: rank) ?? Color("InkFaint")
+        let avatarSize = 26 * scale
+
+        VStack(spacing: 6) {
+            if let e = entry(forRank: rank) {
+                FWFAvatar(name: e.name, size: avatarSize, ring: e.isCurrentUser ? medal : nil)
+            } else {
+                Circle()
+                    .fill(Color("SurfaceAlt"))
+                    .frame(width: avatarSize, height: avatarSize)
+            }
+
+            ZStack(alignment: .top) {
+                UnevenRoundedRectangle(topLeadingRadius: 8, bottomLeadingRadius: 0,
+                                       bottomTrailingRadius: 0, topTrailingRadius: 8,
+                                       style: .continuous)
+                    .fill(medal.opacity(0.9))
+                Text("\(rank)")
+                    .font(.system(size: 15 * scale, weight: .bold))
+                    .monospacedDigit()
+                    .foregroundStyle(.white)
+                    .padding(.top, 5)
+            }
+            .frame(width: 54 * scale, height: stepHeight(rank))
+        }
+        .frame(width: 54 * scale)
+    }
+}
+
+// MARK: - Final result card (completed competition)
+
+/// Replaces the live `CompetitionStandingCard` once a competition has ended.
+/// Shows the user's final placement, the winner / champion treatment, and a podium.
+struct CompetitionResultCard: View {
+    let competitionOverview: CompetitionOverview
+    let loggedInUserId: String?
+
+    private var sortedResults: [UserCompetitionPoints] {
+        competitionOverview.currentResults.sorted()
+    }
+
+    private var placement: Int? {
+        competitionOverview.finalPlacement(for: loggedInUserId)
+    }
+
+    private var won: Bool { placement == 1 }
+
+    private var medalColor: Color? {
+        MedalPalette.color(for: placement)
+    }
+
+    private var participantCount: Int { sortedResults.count }
+
+    private var finalTotalText: String? {
+        guard let row = sortedResults.first(where: { $0.userId == loggedInUserId }),
+              let total = row.totalPoints else { return nil }
+        return ScoringValueFormatter.format(total, unit: competitionOverview.scoringUnit)
+    }
+
+    private var winner: UserCompetitionPoints? {
+        sortedResults.first
+    }
+
+    private var podiumEntries: [MiniPodium.Entry] {
+        sortedResults.prefix(3).enumerated().map { index, points in
+            MiniPodium.Entry(rank: index + 1,
+                             name: points.displayName,
+                             isCurrentUser: points.userId == loggedInUserId)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Your final result")
+                        .font(.system(size: 10.5, weight: .semibold))
+                        .tracking(1.0)
+                        .textCase(.uppercase)
+                        .foregroundStyle(Color("InkMute"))
+
+                    HStack(alignment: .firstTextBaseline, spacing: 5) {
+                        Text(placement.map { CompetitionOverviewViewModel.ordinal($0) } ?? "—")
+                            .font(.system(size: 44, weight: .bold))
+                            .monospacedDigit()
+                            .tracking(-0.02 * 44)
+                            .foregroundStyle(medalColor ?? Color("Ink"))
+                        Text("of \(participantCount)")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(Color("InkMute"))
+                    }
+
+                    if let finalTotalText {
+                        Text("Final total **\(finalTotalText)**")
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color("InkSoft"))
+                    }
+                }
+
+                Spacer()
+
+                if won {
+                    VStack(spacing: 2) {
+                        Text("🏆").font(.system(size: 40))
+                        Text("CHAMPION")
+                            .font(.system(size: 11, weight: .bold))
+                            .tracking(0.9)
+                            .foregroundStyle(Color("Gold"))
+                    }
+                } else if let winner {
+                    VStack(alignment: .trailing, spacing: 6) {
+                        Text("WINNER")
+                            .font(.system(size: 10.5, weight: .semibold))
+                            .tracking(1.0)
+                            .foregroundStyle(Color("InkMute"))
+                        HStack(spacing: 7) {
+                            FWFAvatar(name: winner.displayName, size: 28, ring: Color("Gold"))
+                            Text(winner.firstName)
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(Color("Ink"))
+                        }
+                    }
+                }
+            }
+
+            Divider().background(Color("Border"))
+
+            MiniPodium(entries: podiumEntries, scale: 1.04)
+                .frame(maxWidth: .infinity)
+        }
+        .fwfCard(padding: 18)
+        .overlay(
+            // Tint the surface ~9% toward gold when the user won.
+            Group {
+                if won {
+                    RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        .fill(Color("Gold").opacity(0.09))
+                        .allowsHitTesting(false)
+                }
+            }
+        )
+    }
+}
+
+// MARK: - Recap stats
+
+/// Pure, testable summary of a user's per-day performance across a competition.
+/// Derived from the same daily-summary data the end-of-competition screen uses.
+struct CompetitionRecapStats: Equatable {
+    let totalDays: Int
+    let fullRingDays: Int
+    let bestMoveStreak: Int
+    let activeDays: Int
+    let bestActiveStreak: Int
+    let bestDayValue: Double
+    let bestDayDate: Date?
+    let finalTotal: Double
+
+    static func compute(summaries: [DailySummary], finalTotal: Double) -> CompetitionRecapStats {
+        let chronological = summaries.sorted { $0.date < $1.date }
+
+        var fullRingDays = 0
+        var bestMoveStreak = 0
+        var currentMoveStreak = 0
+        var activeDays = 0
+        var bestActiveStreak = 0
+        var currentActiveStreak = 0
+
+        for summary in chronological {
+            // Full-ring day
+            if closedAllRings(summary) { fullRingDays += 1 }
+
+            // Move-ring streak
+            if summary.caloriesGoal > 0 && summary.caloriesBurned >= summary.caloriesGoal {
+                currentMoveStreak += 1
+                bestMoveStreak = max(bestMoveStreak, currentMoveStreak)
+            } else {
+                currentMoveStreak = 0
+            }
+
+            // Active-day streak (any scored activity)
+            if summary.points > 0 {
+                activeDays += 1
+                currentActiveStreak += 1
+                bestActiveStreak = max(bestActiveStreak, currentActiveStreak)
+            } else {
+                currentActiveStreak = 0
+            }
+        }
+
+        let best = chronological.max { $0.points < $1.points }
+
+        return CompetitionRecapStats(
+            totalDays: chronological.count,
+            fullRingDays: fullRingDays,
+            bestMoveStreak: bestMoveStreak,
+            activeDays: activeDays,
+            bestActiveStreak: bestActiveStreak,
+            bestDayValue: best?.points ?? 0,
+            bestDayDate: best?.date,
+            finalTotal: finalTotal
+        )
+    }
+
+    private static func closedAllRings(_ summary: DailySummary) -> Bool {
+        guard summary.caloriesGoal > 0 else { return false }
+        let move = summary.caloriesBurned >= summary.caloriesGoal
+        let exercise = summary.exerciseTimeGoal == 0 || summary.exerciseTime >= summary.exerciseTimeGoal
+        let stand = summary.standTimeGoal == 0 || summary.standTime >= summary.standTimeGoal
+        return move && exercise && stand
+    }
+}
+
+/// Loads the logged-in user's daily summaries for a completed competition and
+/// derives the recap stats. No new endpoint — reuses `getUserCompetitionDetails`.
+@MainActor
+final class CompetitionRecapViewModel: ObservableObject {
+    @Published private(set) var stats: CompetitionRecapStats?
+
+    private let competitionManager: ICompetitionManager
+    private var hasLoaded = false
+
+    init(competitionManager: ICompetitionManager) {
+        self.competitionManager = competitionManager
+    }
+
+    func loadIfNeeded(competitionId: UUID, userId: String?, finalTotal: Double) async {
+        guard !hasLoaded, let userId else { return }
+        hasLoaded = true
+        do {
+            let details = try await competitionManager.getUserCompetitionDetails(competitionId: competitionId, userId: userId)
+            stats = CompetitionRecapStats.compute(summaries: details.dailySummaries, finalTotal: finalTotal)
+        } catch {
+            Logger.traceError(message: "Failed to load recap summaries for \(competitionId)", error: error)
+        }
+    }
+}
+
+// MARK: - Recap grid
+
+/// 2×2 grid of recap stat cells. Labels are tailored to the competition's
+/// scoring family so a steps/workouts comp doesn't show ring-centric copy.
+struct CompetitionRecapGrid: View {
+    let scoringRules: ScoringRules
+    let scoringUnit: ScoringUnit
+    let stats: CompetitionRecapStats?
+
+    private struct Cell: Identifiable {
+        let id = UUID()
+        let icon: String
+        let color: Color
+        let label: String
+        let value: String
+    }
+
+    private func plain(_ value: Int) -> String { "\(value)" }
+
+    private var cells: [Cell] {
+        let bestDay = stats.map { ScoringValueFormatter.formatCompact($0.bestDayValue, unit: scoringUnit) } ?? "—"
+        let finalTotal = stats.map { ScoringValueFormatter.formatCompact($0.finalTotal, unit: scoringUnit) } ?? "—"
+
+        switch scoringRules.kind {
+        case .rings:
+            return [
+                Cell(icon: "checkmark.circle.fill", color: Color("Brand"),
+                     label: "Full-ring days", value: stats.map { plain($0.fullRingDays) } ?? "—"),
+                Cell(icon: "flame.fill", color: Color("Move"),
+                     label: "Best Move streak", value: stats.map { plain($0.bestMoveStreak) } ?? "—"),
+                Cell(icon: "arrow.up", color: Color("Exercise"),
+                     label: "Best day", value: bestDay),
+                Cell(icon: "trophy", color: Color("Sun"),
+                     label: "Final total", value: finalTotal),
+            ]
+        case .workouts, .daily:
+            return [
+                Cell(icon: "checkmark.circle.fill", color: Color("Brand"),
+                     label: "Active days", value: stats.map { plain($0.activeDays) } ?? "—"),
+                Cell(icon: "flame.fill", color: Color("Move"),
+                     label: "Best streak", value: stats.map { plain($0.bestActiveStreak) } ?? "—"),
+                Cell(icon: "arrow.up", color: Color("Exercise"),
+                     label: "Best day", value: bestDay),
+                Cell(icon: "trophy", color: Color("Sun"),
+                     label: "Final total", value: finalTotal),
+            ]
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Your competition recap")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(Color("Ink"))
+                .padding(.horizontal, 4)
+
+            LazyVGrid(columns: [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)], spacing: 10) {
+                ForEach(cells) { cell in
+                    recapCell(cell)
+                }
+            }
+        }
+    }
+
+    private func recapCell(_ cell: Cell) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: cell.icon)
+                    .font(.system(size: 14))
+                    .foregroundStyle(cell.color)
+                Text(cell.label)
+                    .font(.system(size: 11, weight: .semibold))
+                    .tracking(0.5)
+                    .textCase(.uppercase)
+                    .foregroundStyle(Color("InkMute"))
+            }
+            Text(cell.value)
+                .font(.system(size: 19, weight: .bold))
+                .monospacedDigit()
+                .foregroundStyle(Color("Ink"))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color("Surface"))
+        )
+    }
+}
+
+// MARK: - Scoring rules sheet
+
+/// "How scoring works" bottom sheet. Decodes the competition's `scoringRules`
+/// into human-readable rule blocks plus a worked example. Opened from the
+/// scoring chip and the ? button in the detail header.
+struct ScoringRulesSheet: View {
+    let competitionOverview: CompetitionOverview
+    @Environment(\.dismiss) private var dismiss
+
+    private var scoringChip: CompetitionOverviewViewModel.ScoringChip {
+        CompetitionOverviewViewModel.scoringChip(for: competitionOverview.scoringRules)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                header
+                    .padding(.horizontal, 18)
+                    .padding(.top, 4)
+
+                Text(competitionOverview.scoringRules.humanReadableDescription)
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color("InkSoft"))
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 18)
+                    .padding(.bottom, 2)
+
+                ruleBlocks
+                    .padding(.horizontal, 18)
+            }
+            .padding(.bottom, 28)
+        }
+        .background(Color("Bg"))
+        .presentationDragIndicator(.visible)
+        .presentationDetents([.large])
+        .accessibilityIdentifier("scoringRulesSheet")
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
+                FWFTag(text: "How scoring works", color: Color("InkMute"))
+                Text(competitionOverview.competitionName)
+                    .font(.system(size: 24, weight: .regular, design: .serif))
+                    .tracking(-0.02 * 24)
+                    .foregroundStyle(Color("Ink"))
+                    .fixedSize(horizontal: false, vertical: true)
+                chip(text: scoringChip.label, icon: scoringChip.icon, color: scoringChip.color)
+            }
+
+            Spacer()
+
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color("InkSoft"))
+                    .frame(width: 32, height: 32)
+                    .background(Circle().fill(Color("SurfaceAlt")))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+    }
+
+    @ViewBuilder
+    private var ruleBlocks: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            switch competitionOverview.scoringRules {
+            case let .rings(includedRings, minGoals, dailyCap):
+                ringsBlocks(includedRings: includedRings, minGoals: minGoals, dailyCap: dailyCap)
+            case let .daily(metric):
+                dailyBlocks(metric: metric)
+            case let .workouts(metric, activityTypes):
+                workoutsBlocks(metric: metric, activityTypes: activityTypes)
+            }
+        }
+    }
+
+    // MARK: Rings
+
+    @ViewBuilder
+    private func ringsBlocks(includedRings: Set<ScoringRing>, minGoals: RingMinGoals?, dailyCap: Int?) -> some View {
+        let ptsPerRing = 100
+        let orderedIncluded = ScoringRing.allCases.filter { includedRings.contains($0) }
+        let hasFloor = (minGoals?.isEmpty == false)
+
+        RuleBlock(icon: "flame.fill", color: Color("Move"), title: "Rings that count",
+                  trailing: AnyView(
+                    Text("\(ptsPerRing) pts max / ring / day")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Color("InkMute"))
+                  )) {
+            HStack(spacing: 10) {
+                ForEach(ScoringRing.allCases, id: \.self) { ring in
+                    ringCard(ring: ring, on: includedRings.contains(ring))
+                }
+            }
+            Text("Each day you earn up to **\(ptsPerRing)** points per counted ring, scaled to how far you fill it. Closing a ring 100% banks the full \(ptsPerRing).")
+                .font(.system(size: 12))
+                .foregroundStyle(Color("InkSoft"))
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+
+        RuleBlock(icon: "gauge", color: Color("Brand"), title: "Minimum goal floor",
+                  trailing: AnyView(chip(text: hasFloor ? "On" : "Off",
+                                         color: hasFloor ? Color("Brand") : Color("InkMute")))) {
+            if hasFloor, let minGoals {
+                VStack(spacing: 0) {
+                    let rows = floorRows(minGoals: minGoals, includedRings: includedRings)
+                    ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+                        SpecRow(label: row.label, value: row.value, isLast: index == rows.count - 1)
+                    }
+                }
+                Text("Players whose personal Apple goals sit below the floor are scored as if their goal matched it — so a low goal can't be an easy win. Higher personal goals are used as-is.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color("InkSoft"))
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("No floor is enforced — everyone is scored against their own personal Apple goals.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color("InkSoft"))
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+
+        RuleBlock(icon: "clock", color: Color("Sun"), title: "Daily cap",
+                  trailing: AnyView(chip(text: dailyCap.map { "\($0) pts" } ?? "Off",
+                                         color: dailyCap != nil ? Color("Sun") : Color("InkMute")))) {
+            if let dailyCap {
+                Text("No matter how much you do, a single day can earn at most **\(dailyCap) points**. Keeps one monster session from deciding the competition — consistency wins.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color("InkSoft"))
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("There's no cap — every point you earn in a day counts in full.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color("InkSoft"))
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+
+        ringsWorkedExample(orderedIncluded: orderedIncluded, ptsPerRing: ptsPerRing, dailyCap: dailyCap)
+    }
+
+    private func ringCard(ring: ScoringRing, on: Bool) -> some View {
+        VStack(spacing: 8) {
+            RuleRingGlyph(color: ringColor(ring), fraction: on ? 0.78 : 0.25)
+                .frame(width: 40, height: 40)
+                .opacity(on ? 1 : 0.55)
+            Text(ring.displayName)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Color("Ink"))
+            if on {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 15))
+                    .foregroundStyle(ringColor(ring))
+            } else {
+                Text("Not counted")
+                    .font(.system(size: 10.5, weight: .semibold))
+                    .foregroundStyle(Color("InkFaint"))
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .padding(.horizontal, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(on ? Color("SurfaceAlt") : Color.clear)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(Color("Border"), style: StrokeStyle(lineWidth: on ? 0 : 1, dash: [4, 3]))
+        )
+        .opacity(on ? 1 : 0.6)
+    }
+
+    private func floorRows(minGoals: RingMinGoals, includedRings: Set<ScoringRing>) -> [(label: String, value: String)] {
+        var rows: [(String, String)] = []
+        if includedRings.contains(.calories), let calories = minGoals.calories {
+            rows.append(("Move floor", "\(calories) cal"))
+        }
+        if includedRings.contains(.exercise), let exercise = minGoals.exerciseTime {
+            rows.append(("Exercise floor", "\(exercise) min"))
+        }
+        if includedRings.contains(.stand), let stand = minGoals.standTime {
+            rows.append(("Stand floor", "\(stand) hr"))
+        }
+        return rows
+    }
+
+    private func ringsWorkedExample(orderedIncluded: [ScoringRing], ptsPerRing: Int, dailyCap: Int?) -> some View {
+        var lines: [WorkedExample.Line] = orderedIncluded.map { ring in
+            WorkedExample.Line(label: "Closed \(ring.displayName) ring (100%)", value: "\(ptsPerRing) pts")
+        }
+        let subtotal = ptsPerRing * max(orderedIncluded.count, 1)
+        let resultValue: String
+        if let dailyCap, dailyCap < subtotal {
+            lines.append(WorkedExample.Line(label: "Day subtotal \(subtotal) — over the \(dailyCap) cap", value: "→ \(dailyCap)"))
+            resultValue = "\(dailyCap) pts"
+        } else {
+            resultValue = "\(subtotal) pts"
+        }
+        return WorkedExample(lines: lines, resultLabel: "Points earned that day", resultValue: resultValue)
+    }
+
+    // MARK: Daily
+
+    @ViewBuilder
+    private func dailyBlocks(metric: DailyMetric) -> some View {
+        let unit = competitionOverview.scoringUnit
+        let metricLabel = metric == .steps ? "Steps" : "Walking + running distance"
+        let countNoun = metric == .steps ? "step" : "meter"
+
+        RuleBlock(icon: "shoeprints.fill", color: Color("Brand"), title: "What counts",
+                  trailing: AnyView(chip(text: metricLabel, color: Color("Brand")))) {
+            Text("Every \(countNoun) Apple Health records counts toward your total. There's no goal to clear — just rack up as much as you can over the competition.")
+                .font(.system(size: 12))
+                .foregroundStyle(Color("InkSoft"))
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+
+        RuleBlock(icon: "checkmark.circle.fill", color: Color("InkMute"), title: "No caps or floors") {
+            VStack(spacing: 0) {
+                SpecRow(label: "Daily cap", value: "Off", valueColor: Color("InkMute"),
+                        sub: "Big days count in full.")
+                SpecRow(label: "Minimum goal", value: "Off", valueColor: Color("InkMute"),
+                        sub: "No threshold to clear.", isLast: true)
+            }
+        }
+
+        WorkedExample(
+            lines: [
+                WorkedExample.Line(label: "A strong day", value: ScoringValueFormatter.formatCompact(9_300, unit: unit)),
+                WorkedExample.Line(label: "A rest day", value: ScoringValueFormatter.formatCompact(2_000, unit: unit)),
+                WorkedExample.Line(label: "…added up across every day", value: ""),
+            ],
+            resultLabel: "Highest total wins",
+            resultValue: "Σ \(unitWord(unit))"
+        )
+    }
+
+    // MARK: Workouts
+
+    private func workoutMetricCopy(_ metric: WorkoutMetric) -> (label: String, perUnit: String) {
+        switch metric {
+        case .calories: return ("Calories", "calorie burned in")
+        case .duration: return ("Minutes", "minute of")
+        case .distance: return ("Distance", "meter covered in")
+        }
+    }
+
+    @ViewBuilder
+    private func workoutsBlocks(metric: WorkoutMetric, activityTypes: [UInt]?) -> some View {
+        let metricLabel = workoutMetricCopy(metric).label
+        let perUnit = workoutMetricCopy(metric).perUnit
+        let typeNames = (activityTypes ?? []).compactMap { WorkoutActivityTypeCatalog.displayName(for: $0) }
+
+        RuleBlock(icon: "dumbbell.fill", color: Color("Brand"), title: "What counts",
+                  trailing: AnyView(chip(text: metricLabel, color: Color("Brand")))) {
+            Text("You bank points for every \(perUnit) qualifying workouts. Only the workout types below count\(typeNames.isEmpty ? "" : ", and each has to be logged in Health").")
+                .font(.system(size: 12))
+                .foregroundStyle(Color("InkSoft"))
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+
+        if typeNames.isEmpty {
+            RuleBlock(icon: "checkmark.circle.fill", color: Color("Exercise"), title: "Eligible workout types",
+                      trailing: AnyView(chip(text: "All", color: Color("Exercise")))) {
+                Text("Every workout type tracked in Health counts toward your score.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color("InkSoft"))
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } else {
+            RuleBlock(icon: "checkmark.circle.fill", color: Color("Exercise"), title: "Eligible workout types",
+                      trailing: AnyView(
+                        Text("\(typeNames.count) selected")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Color("InkMute"))
+                      )) {
+                FlowLayout(spacing: 6) {
+                    ForEach(typeNames, id: \.self) { name in
+                        HStack(spacing: 5) {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 10, weight: .bold))
+                            Text(name)
+                                .font(.system(size: 13, weight: .semibold))
+                        }
+                        .foregroundStyle(Color("Brand"))
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Capsule().fill(Color("BrandSoft")))
+                    }
+                }
+                Text("Other workout types are logged in Health but earn **0 points** here.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color("InkSoft"))
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+
+        workoutsWorkedExample(metric: metric, eligibleName: typeNames.first)
+    }
+
+    private func workoutsWorkedExample(metric: WorkoutMetric, eligibleName: String?) -> some View {
+        let name = eligibleName ?? "Run"
+        switch metric {
+        case .duration:
+            return WorkedExample(
+                lines: [
+                    WorkedExample.Line(label: "45-min \(name.lowercased()) (eligible)", value: "45 min"),
+                    WorkedExample.Line(label: "30-min session (eligible)", value: "30 min"),
+                    WorkedExample.Line(label: "An ineligible workout type", value: "0", zero: true),
+                ],
+                resultLabel: "Minutes banked that day",
+                resultValue: "75 min"
+            )
+        case .calories:
+            return WorkedExample(
+                lines: [
+                    WorkedExample.Line(label: "A hard \(name.lowercased()) (eligible)", value: "420 kcal"),
+                    WorkedExample.Line(label: "An ineligible workout type", value: "0", zero: true),
+                ],
+                resultLabel: "Calories banked that day",
+                resultValue: "420 kcal"
+            )
+        case .distance:
+            return WorkedExample(
+                lines: [
+                    WorkedExample.Line(label: "A long \(name.lowercased()) (eligible)", value: "8 km"),
+                    WorkedExample.Line(label: "An ineligible workout type", value: "0", zero: true),
+                ],
+                resultLabel: "Distance banked that day",
+                resultValue: "8 km"
+            )
+        }
+    }
+
+    // MARK: Small helpers
+
+    private func ringColor(_ ring: ScoringRing) -> Color {
+        switch ring {
+        case .calories: return Color("Move")
+        case .exercise: return Color("Exercise")
+        case .stand: return Color("Stand")
+        }
+    }
+
+    private func unitWord(_ unit: ScoringUnit) -> String {
+        switch unit {
+        case .points: return "pts"
+        case .steps: return "steps"
+        case .kcal: return "kcal"
+        case .minutes: return "min"
+        case .meters: return "distance"
+        }
+    }
+
+    private func chip(text: String, icon: String? = nil, color: Color) -> some View {
+        HStack(spacing: 4) {
+            if let icon {
+                Image(systemName: icon)
+                    .font(.system(size: 10, weight: .semibold))
+            }
+            Text(text)
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.6)
+                .textCase(.uppercase)
+        }
+        .foregroundStyle(color)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(color.opacity(0.14)))
+    }
+}
+
+// MARK: - Scoring rules sheet building blocks
+
+private struct RuleBlock<Content: View>: View {
+    let icon: String
+    let color: Color
+    let title: String
+    var trailing: AnyView? = nil
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 9) {
+                Image(systemName: icon)
+                    .font(.system(size: 15))
+                    .foregroundStyle(color)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(color.opacity(0.15))
+                    )
+                Text(title)
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundStyle(Color("Ink"))
+                Spacer(minLength: 8)
+                if let trailing {
+                    trailing
+                }
+            }
+            content()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color("Surface"))
+        )
+    }
+}
+
+private struct SpecRow: View {
+    let label: String
+    var value: String? = nil
+    var valueColor: Color = Color("Ink")
+    var sub: String? = nil
+    var on: Bool = true
+    var isLast: Bool = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label)
+                        .font(.system(size: 14, weight: on ? .semibold : .medium))
+                        .foregroundStyle(Color("Ink"))
+                    if let sub {
+                        Text(sub)
+                            .font(.system(size: 12))
+                            .foregroundStyle(Color("InkSoft"))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 8)
+                if let value {
+                    Text(value)
+                        .font(.system(size: 14, weight: .bold))
+                        .monospacedDigit()
+                        .foregroundStyle(valueColor)
+                }
+            }
+            .padding(.vertical, 10)
+            .opacity(on ? 1 : 0.5)
+
+            if !isLast {
+                Rectangle()
+                    .fill(Color("Border"))
+                    .frame(height: 1)
+            }
+        }
+    }
+}
+
+private struct WorkedExample: View {
+    struct Line {
+        let label: String
+        let value: String
+        var zero: Bool = false
+    }
+
+    let lines: [Line]
+    let resultLabel: String
+    let resultValue: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color("Brand"))
+                Text("WORKED EXAMPLE")
+                    .font(.system(size: 13, weight: .bold))
+                    .tracking(0.8)
+                    .foregroundStyle(Color("Brand"))
+            }
+
+            VStack(spacing: 10) {
+                ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        Text(line.label)
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color("InkSoft"))
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer(minLength: 8)
+                        if !line.value.isEmpty {
+                            Text(line.value)
+                                .font(.system(size: 14, weight: .bold))
+                                .monospacedDigit()
+                                .foregroundStyle(line.zero ? Color("InkMute") : Color("Ink"))
+                        }
+                    }
+                }
+            }
+
+            Rectangle()
+                .fill(Color("Brand").opacity(0.2))
+                .frame(height: 1)
+
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(resultLabel)
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(Color("Ink"))
+                Spacer(minLength: 8)
+                Text(resultValue)
+                    .font(.system(size: 18, weight: .bold))
+                    .monospacedDigit()
+                    .foregroundStyle(Color("Brand"))
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color("BrandSoft"))
+        )
+    }
+}
+
+/// Single activity-ring glyph used inside the rules sheet's "rings that count" cards.
+private struct RuleRingGlyph: View {
+    let color: Color
+    let fraction: CGFloat
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(color.opacity(0.22), lineWidth: 5)
+            Circle()
+                .trim(from: 0, to: fraction)
+                .stroke(color, style: StrokeStyle(lineWidth: 5, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+    }
+}
+
 struct CompetitionDetailView_Previews: PreviewProvider {
     private static var overview: CompetitionOverview {
         let results = [
@@ -431,11 +1488,61 @@ struct CompetitionDetailView_Previews: PreviewProvider {
         )
     }
 
-    static var previews: some View {
-        CompetitionDetailView(
-            competitionOverview: overview,
-            homepageSheetViewModel: HomepageSheetViewModel(appProtocolHandler: MockAppProtocolHandler(), healthKitManager: MockHealthKitManager()),
-            objectGraph: MockObjectGraph()
+    private static func completedOverview(userTotal: Double, rules: ScoringRules = .default) -> CompetitionOverview {
+        let results = [
+            UserCompetitionPoints(userId: "u1", firstName: "Alice", lastName: "Chen",  total: 480, today: 0),
+            UserCompetitionPoints(userId: "u2", firstName: "You",   lastName: "",      total: userTotal, today: 0),
+            UserCompetitionPoints(userId: "u3", firstName: "Marcus", lastName: "Lee",  total: 365, today: 0),
+            UserCompetitionPoints(userId: "u4", firstName: "Sam",   lastName: "Smith", total: 210, today: 0),
+        ]
+        return CompetitionOverview(
+            start: Date().addingTimeInterval(-.xtDays(14)),
+            end: Date().addingTimeInterval(-.xtDays(1)),
+            currentResults: results,
+            scoringRules: rules
         )
+    }
+
+    static var previews: some View {
+        Group {
+            CompetitionDetailView(
+                competitionOverview: overview,
+                homepageSheetViewModel: HomepageSheetViewModel(appProtocolHandler: MockAppProtocolHandler(), healthKitManager: MockHealthKitManager()),
+                objectGraph: MockObjectGraph()
+            )
+            .previewDisplayName("Active")
+
+            CompetitionDetailView(
+                competitionOverview: completedOverview(userTotal: 520),
+                homepageSheetViewModel: HomepageSheetViewModel(appProtocolHandler: MockAppProtocolHandler(), healthKitManager: MockHealthKitManager()),
+                objectGraph: MockObjectGraph()
+            )
+            .previewDisplayName("Completed · Won")
+
+            CompetitionDetailView(
+                competitionOverview: completedOverview(userTotal: 365),
+                homepageSheetViewModel: HomepageSheetViewModel(appProtocolHandler: MockAppProtocolHandler(), healthKitManager: MockHealthKitManager()),
+                objectGraph: MockObjectGraph()
+            )
+            .previewDisplayName("Completed · Off-podium")
+
+            ScoringRulesSheet(competitionOverview: CompetitionOverview(
+                name: "Step Showdown",
+                scoringRules: .daily(metric: .steps)
+            ))
+            .previewDisplayName("Rules · Steps")
+
+            ScoringRulesSheet(competitionOverview: CompetitionOverview(
+                name: "Ring Rumble",
+                scoringRules: .rings(includedRings: [.calories, .exercise], minGoals: RingMinGoals(calories: 500, exerciseTime: 30), dailyCap: 350)
+            ))
+            .previewDisplayName("Rules · Rings")
+
+            ScoringRulesSheet(competitionOverview: CompetitionOverview(
+                name: "Cardio Cup",
+                scoringRules: .workouts(metric: .duration, activityTypes: [37, 52, 13])
+            ))
+            .previewDisplayName("Rules · Workouts")
+        }
     }
 }

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionOverviewView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionOverviewView.swift
@@ -297,6 +297,111 @@ struct CompetitionOverviewView: View {
     }
 }
 
+// MARK: - Compact completed row (collapsed "Completed" drawer)
+
+/// Condensed resting-state row for a finished competition. Drops the live rank
+/// hero + today delta and shows the user's final placement. Used inside the
+/// home-feed "Completed" drawer (Option C).
+struct CompletedCompetitionRow: View {
+    let competitionOverview: CompetitionOverview
+    let loggedInUserId: String?
+    let onTap: () -> Void
+
+    private var placement: Int? {
+        competitionOverview.finalPlacement(for: loggedInUserId)
+    }
+
+    private var participantCount: Int {
+        competitionOverview.currentResults.count
+    }
+
+    private var won: Bool {
+        placement == 1
+    }
+
+    private var medalColor: Color? {
+        MedalPalette.color(for: placement)
+    }
+
+    private var ordinalText: String {
+        guard let placement else { return "—" }
+        return CompetitionOverviewViewModel.ordinal(placement)
+    }
+
+    private var subtitle: String {
+        let ended = "Ended \(MedalPalette.shortMonthDay(competitionOverview.endDate))"
+        guard let placement else { return ended }
+        let placeText = placement == 1 ? "You won" : "\(CompetitionOverviewViewModel.ordinal(placement)) of \(participantCount)"
+        return "\(placeText) · \(ended)"
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                // Leading placement medallion
+                ZStack {
+                    Circle().fill(medalColor?.opacity(0.18) ?? Color("SurfaceAlt"))
+                    Text(ordinalText)
+                        .font(.system(size: 15, weight: .bold))
+                        .monospacedDigit()
+                        .foregroundStyle(medalColor ?? Color("InkSoft"))
+                }
+                .frame(width: 40, height: 40)
+
+                // Name + subtitle
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(competitionOverview.competitionName)
+                        .font(.system(size: 17, weight: .regular, design: .serif))
+                        .foregroundStyle(Color("Ink"))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text(subtitle)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Color("InkMute"))
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                if won {
+                    Text("🏆")
+                        .font(.system(size: 18))
+                }
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(Color("InkFaint"))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("completedCompetitionRow")
+    }
+}
+
+// MARK: - Medal palette helpers
+
+/// Shared medal-color + date helpers used across the completed-competition
+/// treatments (compact row, result card, mini podium).
+enum MedalPalette {
+    /// Gold / Silver / Bronze for placements 1–3, `nil` otherwise.
+    static func color(for placement: Int?) -> Color? {
+        switch placement {
+        case 1: return Color("Gold")
+        case 2: return Color("Silver")
+        case 3: return Color("Bronze")
+        default: return nil
+        }
+    }
+
+    static func shortMonthDay(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        return formatter.string(from: date)
+    }
+}
+
 struct CompetitionOverviewView_Previews: PreviewProvider {
     private static var competitionOverview: CompetitionOverview {
         let results = [
@@ -328,5 +433,37 @@ struct CompetitionOverviewView_Previews: PreviewProvider {
             .fwfCard()
             .padding(.horizontal, 16)
             .background(Color("Bg"))
+
+        VStack(spacing: 0) {
+            CompletedCompetitionRow(
+                competitionOverview: CompetitionOverview(
+                    name: "Spring Step Showdown",
+                    start: Date().addingTimeInterval(-.xtDays(14)),
+                    end: Date().addingTimeInterval(-.xtDays(1)),
+                    currentResults: [
+                        UserCompetitionPoints(userId: "me", firstName: "You", lastName: "", total: 900, today: 0),
+                        UserCompetitionPoints(userId: "a", firstName: "Alice", lastName: "Chen", total: 700, today: 0),
+                    ]),
+                loggedInUserId: "me",
+                onTap: {})
+            Divider()
+            CompletedCompetitionRow(
+                competitionOverview: CompetitionOverview(
+                    name: "April Ring Rumble",
+                    start: Date().addingTimeInterval(-.xtDays(14)),
+                    end: Date().addingTimeInterval(-.xtDays(2)),
+                    currentResults: [
+                        UserCompetitionPoints(userId: "a", firstName: "Alice", lastName: "Chen", total: 700, today: 0),
+                        UserCompetitionPoints(userId: "b", firstName: "Bob", lastName: "Lee", total: 650, today: 0),
+                        UserCompetitionPoints(userId: "c", firstName: "Cara", lastName: "Ng", total: 600, today: 0),
+                        UserCompetitionPoints(userId: "me", firstName: "You", lastName: "", total: 400, today: 0),
+                    ]),
+                loggedInUserId: "me",
+                onTap: {})
+        }
+        .background(Color("Surface"))
+        .padding(.horizontal, 16)
+        .background(Color("Bg"))
+        .previewDisplayName("Completed rows")
     }
 }

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Home/LoggedInContentView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Home/LoggedInContentView.swift
@@ -15,6 +15,10 @@ struct LoggedInContentView: View {
     @StateObject private var homepageViewModel: HomepageViewModel
     @StateObject private var competitionEndAlertViewModel: CompetitionEndAlertViewModel
 
+    // Option C drawer expansion — collapsed by default, persisted per session.
+    @State private var upcomingExpanded = false
+    @State private var completedExpanded = false
+
     init(objectGraph: IObjectGraph) {
         self.objectGraph = objectGraph
         _homepageSheetViewModel = StateObject(wrappedValue: HomepageSheetViewModel(appProtocolHandler: objectGraph.appProtocolHandler,
@@ -75,7 +79,7 @@ struct LoggedInContentView: View {
                             }
                         }
 
-                        // Competitions section
+                        // Competitions section (Option C — focus + drawers)
                         if homepageViewModel.isLoadingCompetitions {
                             ProgressView()
                                 .frame(maxWidth: .infinity)
@@ -83,16 +87,7 @@ struct LoggedInContentView: View {
                                 .fwfCard()
                                 .padding(.horizontal, 16)
                         } else if let competitions = homepageViewModel.currentCompetitions, !competitions.isEmpty {
-                            sectionHeader("Your Competitions")
-
-                            ForEach(competitions) { competitionOverview in
-                                CompetitionOverviewView(objectGraph: objectGraph,
-                                                        competitionOverview: competitionOverview,
-                                                        homepageSheetViewModel: homepageSheetViewModel,
-                                                        showAllDetails: false)
-                                    .fwfCard()
-                                    .padding(.horizontal, 16)
-                            }
+                            competitionGroups(competitions)
                         } else {
                             noCompetitionsEmptyState
                         }
@@ -233,16 +228,76 @@ struct LoggedInContentView: View {
     }
 
     @ViewBuilder
-    private func sectionHeader(_ title: String) -> some View {
-        HStack {
+    private func sectionHeader(_ title: String, count: Int? = nil) -> some View {
+        HStack(spacing: 8) {
             Text(title)
                 .font(.system(size: 19, weight: .semibold))
                 .tracking(-0.02 * 19)
                 .foregroundStyle(Color("Ink"))
+            if let count {
+                Text("\(count)")
+                    .font(.system(size: 13, weight: .semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(Color("InkFaint"))
+            }
             Spacer()
         }
         .padding(.horizontal, 20)
         .padding(.top, 4)
+    }
+
+    // MARK: - Competition groups (Active / Upcoming / Completed)
+
+    @ViewBuilder
+    private func competitionGroups(_ competitions: [CompetitionOverview]) -> some View {
+        let active = competitions.filter { $0.bucket == .active }
+        let upcoming = competitions.filter { $0.bucket == .upcoming }
+        let completed = competitions.filter { $0.bucket == .completed }
+        let loggedInUserId = objectGraph.authenticationManager.loggedInUserId
+
+        if !active.isEmpty {
+            sectionHeader("Active now", count: active.count)
+
+            ForEach(active) { competitionOverview in
+                CompetitionOverviewView(objectGraph: objectGraph,
+                                        competitionOverview: competitionOverview,
+                                        homepageSheetViewModel: homepageSheetViewModel,
+                                        showAllDetails: false)
+                    .fwfCard()
+                    .padding(.horizontal, 16)
+            }
+        }
+
+        if !upcoming.isEmpty {
+            CompetitionGroupDrawer(title: "Upcoming",
+                                   icon: "calendar",
+                                   accent: Color("Sun"),
+                                   data: upcoming,
+                                   isExpanded: $upcomingExpanded) { competitionOverview in
+                UpcomingCompetitionRow(competitionOverview: competitionOverview) {
+                    homepageSheetViewModel.updateState(sheet: .competitionDetails,
+                                                       state: true,
+                                                       contextData: competitionOverview)
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+
+        if !completed.isEmpty {
+            CompetitionGroupDrawer(title: "Completed",
+                                   icon: "trophy",
+                                   accent: Color("Gold"),
+                                   data: completed,
+                                   isExpanded: $completedExpanded) { competitionOverview in
+                CompletedCompetitionRow(competitionOverview: competitionOverview,
+                                        loggedInUserId: loggedInUserId) {
+                    homepageSheetViewModel.updateState(sheet: .competitionDetails,
+                                                       state: true,
+                                                       contextData: competitionOverview)
+                }
+            }
+            .padding(.horizontal, 16)
+        }
     }
 
     private var healthDataMissing: some View {
@@ -279,6 +334,149 @@ struct LoggedInContentView: View {
         .fwfCard()
         .padding(.horizontal, 16)
         .padding(.top, 8)
+    }
+}
+
+// MARK: - Competition group drawer (Option C)
+
+/// Collapsible "drawer" section used for the Upcoming and Completed competition
+/// groups. Collapsed by default; the header toggles expansion with a spring.
+struct CompetitionGroupDrawer<Data: RandomAccessCollection, RowContent: View>: View where Data.Element: Identifiable {
+    let title: String
+    let icon: String
+    let accent: Color
+    let data: Data
+    @Binding var isExpanded: Bool
+    @ViewBuilder let row: (Data.Element) -> RowContent
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var count: Int { data.count }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Button {
+                withAnimation(.spring(duration: 0.4)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: icon)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(accent)
+                        .frame(width: 30, height: 30)
+                        .background(
+                            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                                .fill(accent.opacity(0.16))
+                        )
+
+                    Text(title)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Color("Ink"))
+
+                    Spacer()
+
+                    Text("\(count)")
+                        .font(.system(size: 13, weight: .bold))
+                        .monospacedDigit()
+                        .foregroundStyle(Color("InkMute"))
+
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(Color("InkFaint"))
+                }
+                .padding(.vertical, 14)
+                .padding(.horizontal, 16)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("competitionDrawer_\(title)")
+
+            if isExpanded {
+                hairline
+                ForEach(Array(data.enumerated()), id: \.element.id) { index, element in
+                    row(element)
+                    if index < count - 1 {
+                        hairline
+                    }
+                }
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color("Surface"))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(Color("Border"), lineWidth: colorScheme == .dark ? 1 : 0)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .shadow(color: .black.opacity(colorScheme == .dark ? 0.0 : 0.06), radius: 24, x: 0, y: 8)
+        .shadow(color: .black.opacity(colorScheme == .dark ? 0.0 : 0.04), radius: 2, x: 0, y: 1)
+    }
+
+    private var hairline: some View {
+        Rectangle()
+            .fill(Color("Border"))
+            .frame(height: 1)
+    }
+}
+
+// MARK: - Upcoming competition row (collapsed "Upcoming" drawer)
+
+/// Lightweight resting-state row for a competition that hasn't started yet.
+struct UpcomingCompetitionRow: View {
+    let competitionOverview: CompetitionOverview
+    let onTap: () -> Void
+
+    private var startsInDays: Int {
+        let seconds = competitionOverview.startDate.timeIntervalSince(Date())
+        return max(0, Int(ceil(seconds / 86_400)))
+    }
+
+    private var subtitle: String {
+        let startLabel = MedalPalette.shortMonthDay(competitionOverview.startDate)
+        if startsInDays <= 0 {
+            return "Starting today · \(startLabel)"
+        }
+        return "Starts in \(startsInDays)d · \(startLabel)"
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                ZStack {
+                    Circle().fill(Color("Sun").opacity(0.16))
+                    Image(systemName: "calendar")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Color("Sun"))
+                }
+                .frame(width: 40, height: 40)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(competitionOverview.competitionName)
+                        .font(.system(size: 17, weight: .regular, design: .serif))
+                        .foregroundStyle(Color("Ink"))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text(subtitle)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Color("InkMute"))
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(Color("InkFaint"))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("upcomingCompetitionRow")
     }
 }
 

--- a/Clients/iOS/FitWithFriends/UITests/CompetitionTests.swift
+++ b/Clients/iOS/FitWithFriends/UITests/CompetitionTests.swift
@@ -77,6 +77,69 @@ final class CompetitionTests: FWFUITestBase {
         takeScreenshot(name: "05_CompetitionDetail")
     }
 
+    func testCompletedCompetitionDrawerAndDetail() throws {
+        let competitionId = try createTestCompetition(name: "Completed Comp Test")
+
+        // Shift the window into the past so the competition lands in the Completed bucket.
+        let start = Date(timeIntervalSinceNow: -14 * 24 * 60 * 60)
+        let end = Date(timeIntervalSinceNow: -1 * 24 * 60 * 60)
+        try setCompetitionDates(competitionId: competitionId, start: start, end: end)
+
+        // Seed activity within the new window so standings + recap have real data.
+        try seedSelfActivityData(daysAgo: 14,
+                                 caloriesBurned: 500, caloriesGoal: 400,
+                                 exerciseTime: 35, exerciseTimeGoal: 30,
+                                 standTime: 12, standTimeGoal: 12)
+        try seedCompetitionWithUsers(competitionId: competitionId)
+
+        launchApp(loggedIn: true)
+        XCTAssertTrue(homeScreen.waitForExistence(timeout: 10))
+
+        // The competition sits in the collapsed "Completed" drawer — expand it.
+        let drawer = app.buttons["competitionDrawer_Completed"]
+        XCTAssertTrue(drawer.waitForExistence(timeout: 15))
+        drawer.tap()
+
+        // Tap the compact completed row to open the detail sheet.
+        let row = app.staticTexts["Completed Comp Test"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
+
+        XCTAssertTrue(competitionDetailScreen.waitForExistence(timeout: 5))
+
+        // Completed detail shows the final-result card, recap grid, and final standings
+        // (instead of the live "Time left" standing card).
+        XCTAssertTrue(app.staticTexts["YOUR FINAL RESULT"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Your competition recap"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Final standings"].exists)
+
+        takeScreenshot(name: "11_CompletedCompetitionDetail")
+    }
+
+    func testScoringRulesSheetOpensFromDetail() throws {
+        try createTestCompetition(name: "Rules Sheet Test")
+
+        launchApp(loggedIn: true)
+
+        XCTAssertTrue(homeScreen.waitForExistence(timeout: 10))
+        let competitionText = app.staticTexts["Rules Sheet Test"]
+        XCTAssertTrue(competitionText.waitForExistence(timeout: 15))
+        competitionText.tap()
+
+        XCTAssertTrue(competitionDetailScreen.waitForExistence(timeout: 5))
+
+        // Tap the ? help button in the header to open the "How scoring works" sheet.
+        let helpButton = app.buttons["scoringRulesButton"]
+        XCTAssertTrue(helpButton.waitForExistence(timeout: 5))
+        helpButton.tap()
+
+        // The sheet surfaces its "HOW SCORING WORKS" header tag and a worked example.
+        XCTAssertTrue(app.staticTexts["HOW SCORING WORKS"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["WORKED EXAMPLE"].waitForExistence(timeout: 5))
+
+        takeScreenshot(name: "10_ScoringRulesSheet")
+    }
+
     func testUserDetailsView() throws {
         // Create a competition with activity data
         let competitionId = try createCompetitionForScreenshots(name: "User Detail Test", daysInPast: 3)

--- a/Clients/iOS/FitWithFriends/UITests/FWFUITestBase.swift
+++ b/Clients/iOS/FitWithFriends/UITests/FWFUITestBase.swift
@@ -324,6 +324,22 @@ class FWFUITestBase: XCTestCase {
         XCTAssertEqual(response.statusCode, 200, "Failed to archive competition")
     }
 
+    /// Shift a competition's start/end window via the test helpers endpoint. Used to
+    /// push a competition into the past so it lands in the app's "Completed" bucket
+    /// (the iOS app derives Active/Upcoming/Completed purely from these dates).
+    func setCompetitionDates(competitionId: String, start: Date, end: Date) throws {
+        let formatter = ISO8601DateFormatter()
+        let body: [String: Any] = [
+            "competitionId": competitionId,
+            "startDate": formatter.string(from: start),
+            "endDate": formatter.string(from: end)
+        ]
+        let (_, response) = try makeAuthenticatedRequest(
+            method: "POST", path: "testHelpers/setCompetitionDates", body: body
+        )
+        XCTAssertEqual(response.statusCode, 200, "Failed to set competition dates")
+    }
+
     /// Make the test user a Pro subscriber via the test helpers endpoint
     func makeUserPro() throws {
         guard let userId else { return }

--- a/Clients/iOS/FitWithFriends/UITests/HomeScreenTests.swift
+++ b/Clients/iOS/FitWithFriends/UITests/HomeScreenTests.swift
@@ -24,8 +24,8 @@ final class HomeScreenTests: FWFUITestBase {
         // Verify the competition is visible
         XCTAssertTrue(app.staticTexts["Screenshot Competition"].waitForExistence(timeout: 15))
 
-        // Verify the competitions section header
-        XCTAssertTrue(app.staticTexts["Your Competitions"].exists)
+        // Verify the competitions section header (active competitions group)
+        XCTAssertTrue(app.staticTexts["Active now"].exists)
 
         takeScreenshot(name: "02_HomeScreen")
     }

--- a/Clients/iOS/FitWithFriends/UITests/PublicCompetitionTests.swift
+++ b/Clients/iOS/FitWithFriends/UITests/PublicCompetitionTests.swift
@@ -102,8 +102,8 @@ final class PublicCompetitionTests: FWFUITestBase {
 
         XCTAssertTrue(app.otherElements["homeScreen"].waitForExistence(timeout: 10))
 
-        // Joined public competition appears in "Your Competitions" with a "Public" badge
-        XCTAssertTrue(app.staticTexts["Your Competitions"].waitForExistence(timeout: 15))
+        // Joined public competition appears in the active competitions group with a "Public" badge
+        XCTAssertTrue(app.staticTexts["Active now"].waitForExistence(timeout: 15))
         XCTAssertTrue(app.staticTexts["Joined Public Competition"].waitForExistence(timeout: 15))
         XCTAssertTrue(app.staticTexts["Public"].waitForExistence(timeout: 5))
 

--- a/Clients/iOS/FitWithFriends/UnitTests/HomeRedesignViewModelTests.swift
+++ b/Clients/iOS/FitWithFriends/UnitTests/HomeRedesignViewModelTests.swift
@@ -299,6 +299,98 @@ final class HomeRedesignViewModelTests: XCTestCase {
         XCTAssertTrue(subtitle.contains(","))
     }
 
+    // MARK: - CompetitionOverview.bucket
+
+    func test_bucket_active_whenStartedAndNotEnded() {
+        let comp = CompetitionOverview(start: Date().addingTimeInterval(-.xtDays(2)),
+                                       end: Date().addingTimeInterval(.xtDays(2)))
+        XCTAssertEqual(comp.bucket, .active)
+    }
+
+    func test_bucket_upcoming_whenNotStarted() {
+        let comp = CompetitionOverview(start: Date().addingTimeInterval(.xtDays(2)),
+                                       end: Date().addingTimeInterval(.xtDays(9)))
+        XCTAssertEqual(comp.bucket, .upcoming)
+    }
+
+    func test_bucket_completed_whenEnded() {
+        let comp = CompetitionOverview(start: Date().addingTimeInterval(-.xtDays(9)),
+                                       end: Date().addingTimeInterval(-.xtDays(2)))
+        XCTAssertEqual(comp.bucket, .completed)
+    }
+
+    // MARK: - CompetitionOverview.finalPlacement
+
+    func test_finalPlacement_returnsOneBasedRank() {
+        let leader = UserCompetitionPoints(userId: "alice", firstName: "Alice", lastName: "Chen", total: 500, today: 0)
+        let me = UserCompetitionPoints(userId: "me", firstName: "You", lastName: "", total: 420, today: 0)
+        let last = UserCompetitionPoints(userId: "sam", firstName: "Sam", lastName: "Smith", total: 100, today: 0)
+        let comp = CompetitionOverview(currentResults: [me, last, leader])
+
+        XCTAssertEqual(comp.finalPlacement(for: "alice"), 1)
+        XCTAssertEqual(comp.finalPlacement(for: "me"), 2)
+        XCTAssertEqual(comp.finalPlacement(for: "sam"), 3)
+    }
+
+    func test_finalPlacement_nilWhenUserMissingOrNil() {
+        let comp = CompetitionOverview(currentResults: [
+            UserCompetitionPoints(userId: "alice", firstName: "Alice", lastName: "Chen", total: 500, today: 0)
+        ])
+        XCTAssertNil(comp.finalPlacement(for: "ghost"))
+        XCTAssertNil(comp.finalPlacement(for: nil))
+    }
+
+    // MARK: - CompetitionRecapStats.compute
+
+    func test_recapStats_derivesRingsStreaksAndBestDay() {
+        let day3Date = Date().addingTimeInterval(.xtDays(-1))
+        let summaries = [
+            // day 3 (best day) — full ring, move closed, active
+            DailySummary(date: day3Date,
+                         caloriesBurned: 450, caloriesGoal: 400,
+                         exerciseTime: 30, exerciseTimeGoal: 30,
+                         standTime: 12, standTimeGoal: 12, points: 400),
+            // day 2 — nothing
+            DailySummary(date: Date().addingTimeInterval(.xtDays(-2)),
+                         caloriesBurned: 100, caloriesGoal: 400,
+                         exerciseTime: 0, exerciseTimeGoal: 30,
+                         standTime: 0, standTimeGoal: 12, points: 0),
+            // day 1 — move closed only, active
+            DailySummary(date: Date().addingTimeInterval(.xtDays(-3)),
+                         caloriesBurned: 500, caloriesGoal: 400,
+                         exerciseTime: 10, exerciseTimeGoal: 30,
+                         standTime: 5, standTimeGoal: 12, points: 250),
+            // day 0 — full ring, move closed, active
+            DailySummary(date: Date().addingTimeInterval(.xtDays(-4)),
+                         caloriesBurned: 500, caloriesGoal: 400,
+                         exerciseTime: 35, exerciseTimeGoal: 30,
+                         standTime: 12, standTimeGoal: 12, points: 300),
+        ]
+
+        let stats = CompetitionRecapStats.compute(summaries: summaries, finalTotal: 950)
+
+        XCTAssertEqual(stats.totalDays, 4)
+        XCTAssertEqual(stats.fullRingDays, 2)
+        // day0 + day1 consecutive Move closures = streak of 2 (day2 breaks it)
+        XCTAssertEqual(stats.bestMoveStreak, 2)
+        XCTAssertEqual(stats.activeDays, 3)
+        XCTAssertEqual(stats.bestActiveStreak, 2)
+        XCTAssertEqual(stats.bestDayValue, 400)
+        XCTAssertEqual(stats.bestDayDate, day3Date)
+        XCTAssertEqual(stats.finalTotal, 950)
+    }
+
+    func test_recapStats_emptySummaries_zeroed() {
+        let stats = CompetitionRecapStats.compute(summaries: [], finalTotal: 0)
+        XCTAssertEqual(stats.totalDays, 0)
+        XCTAssertEqual(stats.fullRingDays, 0)
+        XCTAssertEqual(stats.bestMoveStreak, 0)
+        XCTAssertEqual(stats.activeDays, 0)
+        XCTAssertEqual(stats.bestActiveStreak, 0)
+        XCTAssertEqual(stats.bestDayValue, 0)
+        XCTAssertNil(stats.bestDayDate)
+    }
+
     // MARK: - Helpers
 
     private func makeHomepage() -> HomepageViewModel {

--- a/WebService/FitWithFriends/routes/testHelpers.ts
+++ b/WebService/FitWithFriends/routes/testHelpers.ts
@@ -163,4 +163,30 @@ router.post('/setCompetitionArchived', async function (req, res) {
     }
 });
 
+// POST /testHelpers/setCompetitionDates
+// Body: { competitionId: string, startDate: string (ISO), endDate: string (ISO) }
+// Lets UI tests shift a competition's window into the past so it lands in the
+// "Completed" bucket (the iOS app derives Active/Upcoming/Completed from these dates).
+router.post('/setCompetitionDates', async function (req, res) {
+    const competitionId: string = req.body['competitionId'];
+    const startDate: string = req.body['startDate'];
+    const endDate: string = req.body['endDate'];
+
+    if (!competitionId || !startDate || !endDate) {
+        handleError(null, 400, 'Missing required parameter', res);
+        return;
+    }
+
+    try {
+        await CompetitionQueries.updateCompetitionDates({
+            competitionId,
+            startDate: new Date(startDate),
+            endDate: new Date(endDate)
+        });
+        res.sendStatus(200);
+    } catch (error) {
+        handleError(error, 500, 'Error updating competition dates', res);
+    }
+});
+
 export default router;

--- a/WebService/FitWithFriends/sql/competitions.queries.ts
+++ b/WebService/FitWithFriends/sql/competitions.queries.ts
@@ -496,6 +496,38 @@ export function updateCompetitionState(params: IUpdateCompetitionStateParams): P
 }
 
 
+/** 'UpdateCompetitionDates' parameters type */
+export interface IUpdateCompetitionDatesParams {
+  competitionId: string;
+  endDate: DateOrString;
+  startDate: DateOrString;
+}
+
+/** 'UpdateCompetitionDates' return type */
+export type IUpdateCompetitionDatesResult = void;
+
+/** 'UpdateCompetitionDates' query type */
+export interface IUpdateCompetitionDatesQuery {
+  params: IUpdateCompetitionDatesParams;
+  result: IUpdateCompetitionDatesResult;
+}
+
+const updateCompetitionDatesIR: any = {"usedParamSet":{"startDate":true,"endDate":true,"competitionId":true},"params":[{"name":"startDate","required":true,"transform":{"type":"scalar"},"locs":[{"a":37,"b":47}]},{"name":"endDate","required":true,"transform":{"type":"scalar"},"locs":[{"a":61,"b":69}]},{"name":"competitionId","required":true,"transform":{"type":"scalar"},"locs":[{"a":94,"b":108}]}],"statement":"UPDATE competitions SET start_date = :startDate!, end_date = :endDate! WHERE competition_id = :competitionId!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE competitions SET start_date = :startDate!, end_date = :endDate! WHERE competition_id = :competitionId!
+ * ```
+ */
+export function updateCompetitionDates(params: IUpdateCompetitionDatesParams): Promise<Array<IUpdateCompetitionDatesResult>> {
+  return import('@pgtyped/runtime').then(pgtyped => {
+    const updateCompetitionDates = new pgtyped.PreparedQuery<IUpdateCompetitionDatesParams,IUpdateCompetitionDatesResult>(updateCompetitionDatesIR);
+    return updateCompetitionDates.run(params, DatabaseConnectionPool);
+  });
+}
+
+
 /** 'UpdateCompetitionFinalPoints' parameters type */
 export interface IUpdateCompetitionFinalPointsParams {
   competitionId: string;

--- a/WebService/FitWithFriends/sql/competitions.sql
+++ b/WebService/FitWithFriends/sql/competitions.sql
@@ -53,6 +53,9 @@ WHERE state = :state! AND end_date < :finishedBeforeDate!;
 /* @name UpdateCompetitionState */
 UPDATE competitions SET state = :newState! WHERE competition_id = :competitionId!;
 
+/* @name UpdateCompetitionDates */
+UPDATE competitions SET start_date = :startDate!, end_date = :endDate! WHERE competition_id = :competitionId!;
+
 /* @name UpdateCompetitionFinalPoints */
 UPDATE users_competitions
 SET final_points = :finalPoints!

--- a/WebService/FitWithFriends/test/routes/testHelpers.test.ts
+++ b/WebService/FitWithFriends/test/routes/testHelpers.test.ts
@@ -64,6 +64,11 @@ describe('testHelpers route guard', () => {
             const response = await axios.post(`${baseUrl}/seedCompetitionUsers`, {}, { validateStatus: () => true });
             expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 401 }));
         });
+
+        test('setCompetitionDates returns 401', async () => {
+            const response = await axios.post(`${baseUrl}/setCompetitionDates`, {}, { validateStatus: () => true });
+            expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 401 }));
+        });
     });
 
     describe('when FWF_ENABLE_TEST_HELPERS is set to a non-true value', () => {
@@ -80,6 +85,11 @@ describe('testHelpers route guard', () => {
             const response = await axios.post(`${baseUrl}/seedCompetitionUsers`, {}, { validateStatus: () => true });
             expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 401 }));
         });
+
+        test('setCompetitionDates returns 401', async () => {
+            const response = await axios.post(`${baseUrl}/setCompetitionDates`, {}, { validateStatus: () => true });
+            expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 401 }));
+        });
     });
 
     describe('when FWF_ENABLE_TEST_HELPERS=true', () => {
@@ -94,6 +104,11 @@ describe('testHelpers route guard', () => {
 
         test('seedCompetitionUsers passes the guard (returns non-401)', async () => {
             const response = await axios.post(`${baseUrl}/seedCompetitionUsers`, {}, { validateStatus: () => true });
+            expect(response.status).not.toBe(401);
+        });
+
+        test('setCompetitionDates passes the guard (returns non-401)', async () => {
+            const response = await axios.post(`${baseUrl}/setCompetitionDates`, {}, { validateStatus: () => true });
             expect(response.status).not.toBe(401);
         });
     });


### PR DESCRIPTION
Implements the three competitions-UX handoff improvements (chosen direction: **Option C — focus + drawers**).

## 1. Home feed — Active / Upcoming / Completed
- Splits the flat competition list into date-derived buckets.
- Active competitions stay full-size in focus; **Upcoming** and **Completed** collapse into tappable `CompetitionGroupDrawer` rows (spring expand/collapse, collapsed by default).
- New compact `UpcomingCompetitionRow` and `CompletedCompetitionRow`.

## 2. Completed competition rendering
- `CompetitionOverview.bucket` + `finalPlacement(for:)` date-derived helpers.
- `CompletedCompetitionRow`: medal placement medallion, "You won / Nth of N · Ended {date}", 🏆 + chevron.
- Detail view branches on completed state:
  - `CompetitionResultCard` (placement hero + champion/winner treatment + `MiniPodium`) replaces the live "Time left" standing card.
  - `CompetitionRecapGrid` (2×2, labels tailored per scoring family).
  - "Final standings" leaderboard + **Defend your title / Demand a rematch** CTA stack.
  - Recap stats reuse the existing `getUserCompetitionDetails` data (no new network calls), derived by the testable `CompetitionRecapStats.compute`.

## 3. Scoring rules sheet
- `ScoringRulesSheet` decodes `scoringRules` into human-readable rule blocks + a worked example, per kind (rings / daily / workouts).
- Opened from the now-tappable scoring chip **and** a new `?` button in the detail header (which also surfaces "Ended {date}").
- Surfaces only configuration the model actually carries rather than mock placeholders.

## Testing
- **Unit:** `bucket`, `finalPlacement`, `CompetitionRecapStats` (added to `HomeRedesignViewModelTests`). Full iOS unit target: 222 pass.
- **UI:** new `testScoringRulesSheetOpensFromDetail` and `testCompletedCompetitionDrawerAndDetail` (drives drawer → row → result card → recap → final standings). Updated two stale `"Your Competitions"` → `"Active now"` assertions. All affected UI classes pass.
- **Backend:** new `POST /testHelpers/setCompetitionDates` route + `UpdateCompetitionDates` query lets UI tests push a competition into the past (the app buckets purely by date). Guard tests added — 9/9 pass.

## Notes for reviewers
- New components live inside existing project-referenced files (the `.xcodeproj` uses a manual file list); easy to extract into the handoff's suggested files later.
- The won-state gold tint on the result card is a subtle 9% overlay — worth an eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)