### PR TITLE
Fix create-competition UI bugs, add public competition preview, fix rematch flow

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends.xcodeproj/project.pbxproj
+++ b/Clients/iOS/FitWithFriends/FitWithFriends.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		FWF0000200000000000000E1 /* MockSubscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FWF0000200000000000000E0 /* MockSubscriptionManager.swift */; };
 		FWF0000200000000000000E3 /* MockSubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FWF0000200000000000000E2 /* MockSubscriptionService.swift */; };
 		FWF0000200000000000000E5 /* PublicCompetitionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FWF0000200000000000000E4 /* PublicCompetitionCard.swift */; };
+		FWF000020000000000000119 /* PublicCompetitionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FWF000020000000000000118 /* PublicCompetitionDetailView.swift */; };
 		FWF0000200000000000000E7 /* ScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FWF0000200000000000000E6 /* ScreenshotTests.swift */; };
 		FWF0000200000000000000E9 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FWF0000200000000000000E8 /* SnapshotHelper.swift */; };
 		FWF0000200000000000000F0 /* IosBuildVersionsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FWF0000200000000000000F1 /* IosBuildVersionsDTO.swift */; };
@@ -612,6 +613,7 @@
 		FWF0000200000000000000E0 /* MockSubscriptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSubscriptionManager.swift; sourceTree = "<group>"; };
 		FWF0000200000000000000E2 /* MockSubscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSubscriptionService.swift; sourceTree = "<group>"; };
 		FWF0000200000000000000E4 /* PublicCompetitionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicCompetitionCard.swift; sourceTree = "<group>"; };
+		FWF000020000000000000118 /* PublicCompetitionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicCompetitionDetailView.swift; sourceTree = "<group>"; };
 		FWF0000200000000000000E6 /* ScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests.swift; sourceTree = "<group>"; };
 		FWF0000200000000000000E8 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		FWF0000200000000000000F1 /* IosBuildVersionsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosBuildVersionsDTO.swift; sourceTree = "<group>"; };
@@ -1138,6 +1140,7 @@
 				0B1CBECD27C3F7B40008C72A /* JoinCompetitionView.swift */,
 				0BD8B5BE27D42C92009BA5F2 /* CompetitionDetailView.swift */,
 				FWF0000200000000000000E4 /* PublicCompetitionCard.swift */,
+				FWF000020000000000000118 /* PublicCompetitionDetailView.swift */,
 				A1B2C3D4E5F6000000000007 /* UserCompetitionDailyDetailsView.swift */,
 				FWF0000300000000000000A1 /* CompetitionEndView.swift */,
 			);
@@ -1665,6 +1668,7 @@
 				0BC192AF2B12E6C300C3F4FA /* SecretConstants.swift in Sources */,
 				0B47A252279E424300C2970E /* CompetitionOverviewView.swift in Sources */,
 				FWF0000200000000000000E5 /* PublicCompetitionCard.swift in Sources */,
+				FWF000020000000000000119 /* PublicCompetitionDetailView.swift in Sources */,
 				0B329F0E2E4C2CAA0082D211 /* IAppleAuthenticationManager.swift in Sources */,
 				0B329F0F2E4C2CAA0082D211 /* IAuthenticationManager.swift in Sources */,
 				0B329F172E4D79900082D211 /* UserCompetitionPoints.swift in Sources */,

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Competitions/CompetitionManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Competitions/CompetitionManager.swift
@@ -166,6 +166,10 @@ public class CompetitionManager: ICompetitionManager, ObservableObject {
         }
     }
 
+    func getPublicCompetitionOverview(competitionId: UUID) async throws -> CompetitionOverview {
+        return try await competitionService.getPublicCompetitionOverview(competitionId: competitionId)
+    }
+
     func getUserCompetitionDetails(competitionId: UUID, userId: String) async throws -> UserCompetitionDailyDetails {
         return try await competitionService.getUserCompetitionDetails(competitionId: competitionId, userId: userId)
     }

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Competitions/ICompetitionManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Competitions/ICompetitionManager.swift
@@ -80,6 +80,12 @@ protocol ICompetitionManager: AnyObject {
     /// Join a public competition
     func joinPublicCompetition(competitionId: UUID) async throws
 
+    /// Get the overview (scoring rules + live standings) for a public competition.
+    /// The user does not need to be a member - used to preview a public competition before joining.
+    /// - Parameter competitionId: The competition id
+    /// - Returns: The competition overview
+    func getPublicCompetitionOverview(competitionId: UUID) async throws -> CompetitionOverview
+
     /// Get daily activity details for a specific user in a competition
     /// - Parameters:
     ///   - competitionId: The competition id

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/CompetitionService.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/CompetitionService.swift
@@ -96,6 +96,14 @@ public class CompetitionService: ServiceBase, ICompetitionService {
                                                            method: .get)
     }
 
+    public func getPublicCompetitionOverview(competitionId: UUID) async throws -> CompetitionOverview {
+        // Need to query using the user's current timezone so we get accurate information on whether the competition is active or not
+        let ianaTimezone = TimeZone.current.identifier
+
+        return try await makeRequestWithUserAuthentication(url: "\(serverEnvironmentManager.baseUrl)/competitions/\(competitionId.uuidString)/publicOverview?timezone=\(ianaTimezone)",
+                                                           method: .get)
+    }
+
     public func joinPublicCompetition(competitionId: UUID) async throws {
         let requestBody: [String: String] = [
             "competitionId": competitionId.uuidString

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/ICompetitionService.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Data/Service/ICompetitionService.swift
@@ -63,6 +63,13 @@ public protocol ICompetitionService {
     /// Get the list of active public competitions
     func getPublicCompetitions() async throws -> PublicCompetitionsResponse
 
+    /// Get the overview (scoring rules + live standings) for a public competition.
+    /// The user does NOT need to be a member - this is used to preview a public
+    /// competition before joining. Only works for public competitions.
+    /// - Parameter competitionId: The competition id
+    /// - Returns: The competition overview, or a relevant error
+    func getPublicCompetitionOverview(competitionId: UUID) async throws -> CompetitionOverview
+
     /// Join a public competition (requires Pro subscription)
     /// - Parameter competitionId: The competition to join
     func joinPublicCompetition(competitionId: UUID) async throws

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Mocks/MockCompetitionManager.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Mocks/MockCompetitionManager.swift
@@ -175,6 +175,26 @@ public class MockCompetitionManager: ICompetitionManager {
         }
     }
 
+    public var param_getPublicCompetitionOverview_competitionId: UUID?
+    public var return_getPublicCompetitionOverview: CompetitionOverview?
+    public var return_getPublicCompetitionOverview_error: Error?
+
+    public var getPublicCompetitionOverviewCallCount = 0
+    public func getPublicCompetitionOverview(competitionId: UUID) async throws -> CompetitionOverview {
+        getPublicCompetitionOverviewCallCount += 1
+        param_getPublicCompetitionOverview_competitionId = competitionId
+
+        if let error = return_getPublicCompetitionOverview_error {
+            throw error
+        }
+
+        guard let overview = return_getPublicCompetitionOverview else {
+            throw NSError(domain: "Mock", code: 0, userInfo: nil)
+        }
+
+        return overview
+    }
+
     public var param_getUserCompetitionDetails_competitionId: UUID?
     public var param_getUserCompetitionDetails_userId: String?
     public var return_getUserCompetitionDetails: UserCompetitionDailyDetails?

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Mocks/MockCompetitionService.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Mocks/MockCompetitionService.swift
@@ -136,6 +136,20 @@ public class MockCompetitionService: ICompetitionService {
         }
     }
 
+    public var param_getPublicCompetitionOverview_competitionId: UUID?
+    public var return_getPublicCompetitionOverview: CompetitionOverview?
+    public var getPublicCompetitionOverviewCallCount = 0
+    public func getPublicCompetitionOverview(competitionId: UUID) async throws -> CompetitionOverview {
+        getPublicCompetitionOverviewCallCount += 1
+        param_getPublicCompetitionOverview_competitionId = competitionId
+
+        if let retVal = return_getPublicCompetitionOverview {
+            return retVal
+        } else {
+            throw HttpError.generic
+        }
+    }
+
     public var param_joinPublicCompetition_competitionId: UUID?
     public var return_joinPublicCompetition_error: Error?
     public var joinPublicCompetitionCallCount = 0

--- a/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Competitions/CreateCompetitionViewModel.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Competitions/CreateCompetitionViewModel.swift
@@ -114,7 +114,6 @@ public class CreateCompetitionViewModel: ObservableObject {
 
     // Daily config
     @Published var dailyMetric: DailyMetric = .steps
-    @Published var dailyTarget: Int = 8000  // visual reference only — not sent to the server
 
     /// Name of the competition that was just created — the invite step uses this
     /// to look up the new competition from the manager's published overviews and

--- a/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Home/HomepageSheetViewModel.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Home/HomepageSheetViewModel.swift
@@ -23,6 +23,7 @@ public class HomepageSheetViewModel: ObservableObject {
         case joinCompetition
         case createCompetition
         case competitionDetails
+        case publicCompetitionDetails
         case userDetails
         case proUpgrade
         case settings
@@ -43,6 +44,7 @@ public class HomepageSheetViewModel: ObservableObject {
         .joinCompetition: (shouldShow: false, contextData: nil),
         .createCompetition: (shouldShow: false, contextData: nil),
         .competitionDetails: (shouldShow: false, contextData: nil),
+        .publicCompetitionDetails: (shouldShow: false, contextData: nil),
         .userDetails: (shouldShow: false, contextData: nil),
         .proUpgrade: (shouldShow: false, contextData: nil),
         .settings: (shouldShow: false, contextData: nil),

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/About/SettingsView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/About/SettingsView.swift
@@ -182,7 +182,7 @@ struct SettingsView: View {
                 .tracking(-0.5)
                 .foregroundStyle(.white)
 
-                Text("Up to 10 simultaneous competitions, custom scoring, public leaderboards. $19.99/yr.")
+                Text("Up to 10 simultaneous competitions, custom scoring, public leaderboards. $2.99/mo.")
                     .font(.system(size: 12.5))
                     .foregroundStyle(.white.opacity(0.85))
                     .fixedSize(horizontal: false, vertical: true)

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionDetailView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionDetailView.swift
@@ -12,6 +12,10 @@ struct CompetitionDetailView: View {
     private let homepageSheetViewModel: HomepageSheetViewModel
     private let objectGraph: IObjectGraph
     private let viewModel: CompetitionDetailViewModel
+    /// Invoked when the user taps the rematch CTA on a completed competition. The parent
+    /// opens the create wizard from this sheet's onDismiss — presenting it here, while the
+    /// sheet is still animating out, gets dropped by SwiftUI.
+    private let onRematch: () -> Void
 
     @Environment(\.dismiss) private var dismiss
     @State private var actionInProgress = false
@@ -23,10 +27,12 @@ struct CompetitionDetailView: View {
 
     init(competitionOverview: CompetitionOverview,
          homepageSheetViewModel: HomepageSheetViewModel,
-         objectGraph: IObjectGraph) {
+         objectGraph: IObjectGraph,
+         onRematch: @escaping () -> Void = {}) {
         self.competitionOverview = competitionOverview
         self.homepageSheetViewModel = homepageSheetViewModel
         self.objectGraph = objectGraph
+        self.onRematch = onRematch
         viewModel = CompetitionDetailViewModel(competitionManager: objectGraph.competitionManager,
                                                homepageSheetViewModel: homepageSheetViewModel)
         _recapViewModel = StateObject(wrappedValue: CompetitionRecapViewModel(competitionManager: objectGraph.competitionManager))
@@ -157,13 +163,13 @@ struct CompetitionDetailView: View {
     private var completedCtaStack: some View {
         VStack(spacing: 10) {
             FWFPrimaryButton(didWin ? "Defend your title" : "Demand a rematch", icon: "trophy") {
-                // Dismiss the detail sheet, then present the create wizard — mirrors
-                // the rematch behavior in CompetitionEndView.
+                // Signal the parent to open the create wizard from this sheet's onDismiss,
+                // then dismiss. Opening it here races the dismissal animation and SwiftUI
+                // silently drops the presentation. Mirrors CompetitionEndView.
+                onRematch()
                 dismiss()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                    homepageSheetViewModel.updateState(sheet: .createCompetition, state: true)
-                }
             }
+            .accessibilityIdentifier("competitionDetailRematchButton")
 
             FWFSecondaryButton(didWin ? "Share your win" : "Share recap", icon: "square.and.arrow.up") {
                 shareCompetition()
@@ -941,7 +947,7 @@ struct ScoringRulesSheet: View {
             VStack(alignment: .leading, spacing: 12) {
                 header
                     .padding(.horizontal, 18)
-                    .padding(.top, 4)
+                    .padding(.top, 24)
 
                 Text(competitionOverview.scoringRules.humanReadableDescription)
                     .font(.system(size: 14))

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionEndView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionEndView.swift
@@ -13,7 +13,10 @@ import SwiftUI
 
 struct CompetitionEndView: View {
     @ObservedObject var viewModel: CompetitionEndAlertViewModel
-    let homepageSheetViewModel: HomepageSheetViewModel
+    /// Invoked when the user taps the rematch / new-competition CTA. The parent is
+    /// responsible for opening the create wizard once this cover has fully dismissed —
+    /// presenting it here (while the cover is still animating out) gets dropped by SwiftUI.
+    var onRematch: () -> Void = {}
     @Environment(\.dismiss) private var dismiss
 
     @State private var showingShare: Bool = false
@@ -345,13 +348,14 @@ struct CompetitionEndView: View {
         VStack(spacing: 10) {
             // Primary CTA — "Demand a rematch" or "Rematch" depending on variant.
             FWFPrimaryButton(rematchCtaTitle) {
+                // Signal the parent to open the create wizard from the cover's
+                // onDismiss, then dismiss. Opening it here races the dismissal
+                // animation and SwiftUI silently drops the presentation.
+                onRematch()
                 viewModel.dismissCurrent()
                 dismiss()
-                // Pop the create wizard so the user can spin up a new comp immediately.
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                    homepageSheetViewModel.updateState(sheet: .createCompetition, state: true)
-                }
             }
+            .accessibilityIdentifier("competitionEndRematchButton")
 
             FWFSecondaryButton(shareCtaTitle, icon: "square.and.arrow.up") {
                 showingShare = true
@@ -389,10 +393,6 @@ struct CompetitionEndView_Previews: PreviewProvider {
             viewModel: CompetitionEndAlertViewModel(
                 competitionManager: MockCompetitionManager(),
                 authenticationManager: MockAuthenticationManager()
-            ),
-            homepageSheetViewModel: HomepageSheetViewModel(
-                appProtocolHandler: MockAppProtocolHandler(),
-                healthKitManager: MockHealthKitManager()
             )
         )
     }

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CreateCompetitionView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CreateCompetitionView.swift
@@ -382,7 +382,7 @@ struct CreateScoringStep: View {
                         .foregroundStyle(Color("Sun"))
                 }
             }
-            .foregroundStyle(selected ? .white : Color("Ink"))
+            .foregroundStyle(selected ? Color("Bg") : Color("Ink"))
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)
             .background(
@@ -591,29 +591,6 @@ struct CreateScoringStep: View {
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Daily target")
-                    .font(.system(size: 14, weight: .semibold))
-                Slider(value: Binding(
-                    get: { Double(viewModel.dailyTarget) },
-                    set: { viewModel.dailyTarget = Int($0) }
-                ), in: 2000...25000, step: 500)
-                .tint(Color("Brand"))
-                HStack {
-                    Text("Light · 2k").font(.system(size: 10)).foregroundStyle(Color("InkFaint"))
-                    Spacer()
-                    Text("Typical · 7.5k").font(.system(size: 10)).foregroundStyle(Color("InkFaint"))
-                    Spacer()
-                    Text("Active · 15k").font(.system(size: 10)).foregroundStyle(Color("InkFaint"))
-                    Spacer()
-                    Text("Athlete · 25k").font(.system(size: 10)).foregroundStyle(Color("InkFaint"))
-                }
-                Text("Visual reference only — every \(viewModel.dailyMetric == .steps ? "step" : "meter") still counts toward the total.")
-                    .font(.system(size: 11))
-                    .foregroundStyle(Color("InkSoft"))
-            }
-            .fwfCard(padding: 14)
-
-            VStack(alignment: .leading, spacing: 6) {
                 Text("How it works")
                     .font(.system(size: 14, weight: .semibold))
                 Text("Each day, points are added up. Highest total at the end wins.")
@@ -629,10 +606,10 @@ struct CreateScoringStep: View {
             VStack(spacing: 6) {
                 Image(systemName: icon)
                     .font(.system(size: 20))
-                    .foregroundStyle(selected ? .white : Color("Brand"))
+                    .foregroundStyle(selected ? Color("Bg") : Color("Brand"))
                 Text(label)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(selected ? .white : Color("Ink"))
+                    .foregroundStyle(selected ? Color("Bg") : Color("Ink"))
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 18)
@@ -719,7 +696,7 @@ struct CreateScoringStep: View {
         } label: {
             Text(label)
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(selected ? .white : Color("Ink"))
+                .foregroundStyle(selected ? Color("Bg") : Color("Ink"))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 8)
                 .background(
@@ -737,7 +714,7 @@ struct CreateScoringStep: View {
         } label: {
             Text("\(mins) min")
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(selected ? .white : Color("Ink"))
+                .foregroundStyle(selected ? Color("Bg") : Color("Ink"))
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
                 .background(
@@ -758,7 +735,7 @@ struct CreateScoringStep: View {
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(Color("Ink"))
             }
-            Text("Custom scoring rules and non-rings modes are part of FitWithFriends Pro ($19.99/year).")
+            Text("Custom scoring rules and non-rings modes are part of FitWithFriends Pro ($2.99/month).")
                 .font(.system(size: 12))
                 .foregroundStyle(Color("InkSoft"))
             Button("See what Pro unlocks →") { onShowProUpgrade() }
@@ -776,7 +753,7 @@ struct CreateScoringStep: View {
     @ViewBuilder
     private var submitButton: some View {
         if viewModel.requiresProUserMissing {
-            FWFPrimaryButton("Start Pro · $19.99/yr") { onShowProUpgrade() }
+            FWFPrimaryButton("Start Pro · $2.99/mo") { onShowProUpgrade() }
                 .accessibilityIdentifier("createCompetitionProUpgradeButton")
                 .accessibilityLabel("Upgrade to Pro")
         } else {

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/PublicCompetitionCard.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/PublicCompetitionCard.swift
@@ -12,6 +12,9 @@ struct PublicCompetitionCard: View {
     let isUserPro: Bool
     let onJoin: () -> Void
     let onUpgrade: () -> Void
+    /// Invoked when the card body is tapped to preview the competition details
+    /// (scoring rules + live leaderboard) before joining.
+    let onSelect: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -57,6 +60,17 @@ struct PublicCompetitionCard: View {
                 .foregroundStyle(.secondary)
             }
 
+            // Tappable affordance to preview the competition before joining
+            HStack(spacing: 4) {
+                Text("View leaderboard & scoring")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Color("Brand"))
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color("Brand"))
+            }
+
             Divider()
 
             // Action row
@@ -92,5 +106,10 @@ struct PublicCompetitionCard: View {
                 .buttonStyle(.plain)
             }
         }
+        // The inner Join / Upgrade buttons handle their own taps; tapping anywhere
+        // else on the card opens the details preview.
+        .contentShape(Rectangle())
+        .onTapGesture { onSelect() }
+        .accessibilityIdentifier("publicCompetitionCard")
     }
 }

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/PublicCompetitionDetailView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/PublicCompetitionDetailView.swift
@@ -1,0 +1,250 @@
+//
+//  PublicCompetitionDetailView.swift
+//  FitWithFriends
+//
+//  Preview of a public competition the user has not joined yet. Loads the
+//  competition's scoring rules and live leaderboard from the public (non-member)
+//  overview endpoint so the user can size up a competition before deciding to
+//  join. The leaderboard rows are read-only here — drilling into a specific
+//  user's daily details requires membership.
+//
+
+import SwiftUI
+
+struct PublicCompetitionDetailView: View {
+    let competition: PublicCompetition
+    let isUserPro: Bool
+    let homepageSheetViewModel: HomepageSheetViewModel
+    let objectGraph: IObjectGraph
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var overview: CompetitionOverview?
+    @State private var isLoading = true
+    @State private var loadFailed = false
+    @State private var showScoringRules = false
+    @State private var joinInProgress = false
+
+    private var loggedInUserId: String? {
+        objectGraph.authenticationManager.loggedInUserId
+    }
+
+    var body: some View {
+        NavigationView {
+            ZStack(alignment: .top) {
+                Color("Bg").ignoresSafeArea()
+
+                ScrollView {
+                    Text("publicCompetitionDetailScreen")
+                        .frame(width: 0, height: 0)
+                        .opacity(0.001)
+                        .accessibilityIdentifier("publicCompetitionDetailScreen")
+
+                    VStack(spacing: 16) {
+                        Spacer().frame(height: 56)  // room for floating back button
+
+                        if let overview {
+                            CompetitionDetailHeaderView(competitionOverview: overview,
+                                                        isCompleted: overview.bucket == .completed,
+                                                        onShowScoringRules: { showScoringRules = true })
+                                .padding(.horizontal, 20)
+
+                            leaderboard(overview)
+                                .padding(.horizontal, 16)
+                        } else if isLoading {
+                            ProgressView("Loading competition…")
+                                .padding(.top, 80)
+                        } else {
+                            loadErrorState
+                                .padding(.horizontal, 20)
+                                .padding(.top, 40)
+                        }
+
+                        Spacer().frame(height: 120)  // room for floating join CTA
+                    }
+                }
+
+                floatingBack
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+            }
+            .safeAreaInset(edge: .bottom) {
+                joinCtaBar
+            }
+            .navigationBarHidden(true)
+            .presentationDragIndicator(.visible)
+            .task { await load() }
+            .sheet(isPresented: $showScoringRules) {
+                if let overview {
+                    ScoringRulesSheet(competitionOverview: overview)
+                }
+            }
+        }
+    }
+
+    // MARK: - Leaderboard
+
+    @ViewBuilder
+    private func leaderboard(_ overview: CompetitionOverview) -> some View {
+        let sortedResults = overview.currentResults.sorted()
+
+        VStack(spacing: 10) {
+            HStack {
+                Text(overview.bucket == .completed ? "Final standings" : "Leaderboard")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(Color("Ink"))
+                Spacer()
+            }
+            .padding(.horizontal, 4)
+
+            if sortedResults.isEmpty {
+                Text("No one has joined yet — be the first!")
+                    .font(.subheadline)
+                    .foregroundStyle(Color("InkSoft"))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 24)
+                    .fwfCard()
+            } else {
+                ForEach(Array(sortedResults.enumerated()), id: \.offset) { index, points in
+                    let position = UserPosition(userCompetitionPoints: points, position: UInt(index + 1))
+                    UserCompetitionResultView(
+                        result: position,
+                        isCompetitionActive: overview.isCompetitionActive,
+                        scoringUnit: overview.scoringUnit,
+                        isCurrentUser: points.userId == loggedInUserId
+                    )
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("publicCompetitionLeaderboard")
+    }
+
+    private var loadErrorState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "wifi.exclamationmark")
+                .font(.system(size: 32))
+                .foregroundStyle(Color("InkMute"))
+            Text(competition.displayName)
+                .font(.system(size: 22, weight: .semibold, design: .serif))
+                .foregroundStyle(Color("Ink"))
+                .multilineTextAlignment(.center)
+            Text("We couldn't load this competition's details. Check your connection and try again.")
+                .font(.subheadline)
+                .foregroundStyle(Color("InkSoft"))
+                .multilineTextAlignment(.center)
+            FWFSecondaryButton("Try again", icon: "arrow.clockwise") {
+                Task { await load() }
+            }
+            .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity)
+        .fwfCard()
+    }
+
+    // MARK: - Floating chrome
+
+    private var floatingBack: some View {
+        HStack {
+            Button { dismiss() } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(Color("Ink"))
+                    .frame(width: 38, height: 38)
+                    .background(Circle().fill(Color("Surface")))
+                    .shadow(color: Color("Ink").opacity(0.10), radius: 8, x: 0, y: 2)
+            }
+            .buttonStyle(.plain)
+            Spacer()
+        }
+    }
+
+    // MARK: - Join CTA
+
+    @ViewBuilder
+    private var joinCtaBar: some View {
+        VStack(spacing: 0) {
+            Divider().background(Color("Border"))
+
+            Group {
+                if competition.isUserMember {
+                    Label("You've joined", systemImage: "checkmark.circle.fill")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color("Brand"))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                } else if isUserPro {
+                    FWFPrimaryButton(joinInProgress ? "Joining…" : "Join Competition") {
+                        join()
+                    }
+                    .disabled(joinInProgress)
+                    .accessibilityIdentifier("publicCompetitionJoinButton")
+                } else {
+                    FWFPrimaryButton("Upgrade to Pro", icon: "star.fill") {
+                        dismiss()
+                        homepageSheetViewModel.updateState(sheet: .proUpgrade, state: true)
+                    }
+                    .accessibilityIdentifier("publicCompetitionUpgradeButton")
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color("Bg"))
+        }
+    }
+
+    // MARK: - Actions
+
+    private func load() async {
+        await MainActor.run {
+            isLoading = true
+            loadFailed = false
+        }
+        do {
+            let result = try await objectGraph.competitionManager.getPublicCompetitionOverview(competitionId: competition.competitionId)
+            await MainActor.run {
+                self.overview = result
+                self.isLoading = false
+            }
+        } catch {
+            Logger.traceError(message: "Failed to load public competition overview for \(competition.competitionId)", error: error)
+            await MainActor.run {
+                self.loadFailed = true
+                self.isLoading = false
+            }
+        }
+    }
+
+    private func join() {
+        joinInProgress = true
+        Task {
+            do {
+                try await objectGraph.competitionManager.joinPublicCompetition(competitionId: competition.competitionId)
+                await MainActor.run {
+                    joinInProgress = false
+                    dismiss()
+                }
+            } catch {
+                Logger.traceError(message: "Failed to join public competition \(competition.competitionId)", error: error)
+                await MainActor.run { joinInProgress = false }
+            }
+        }
+    }
+}
+
+struct PublicCompetitionDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        PublicCompetitionDetailView(
+            competition: PublicCompetition(competitionId: UUID(),
+                                           displayName: "City Step Showdown",
+                                           startDate: Date(),
+                                           endDate: Date().addingTimeInterval(7 * 86_400),
+                                           memberCount: 12,
+                                           isUserMember: false),
+            isUserPro: true,
+            homepageSheetViewModel: HomepageSheetViewModel(appProtocolHandler: MockAppProtocolHandler(),
+                                                           healthKitManager: MockHealthKitManager()),
+            objectGraph: MockObjectGraph()
+        )
+    }
+}

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Home/LoggedInContentView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Home/LoggedInContentView.swift
@@ -19,6 +19,14 @@ struct LoggedInContentView: View {
     @State private var upcomingExpanded = false
     @State private var completedExpanded = false
 
+    // Set when the user taps rematch on the competition-end cover; consumed in the
+    // cover's onDismiss to open the create wizard after the cover finishes dismissing.
+    @State private var shouldShowCreateAfterEnd = false
+
+    // Same handoff for the completed-competition detail sheet's rematch CTA — consumed
+    // in the detail sheet's onDismiss.
+    @State private var shouldShowCreateAfterDetail = false
+
     init(objectGraph: IObjectGraph) {
         self.objectGraph = objectGraph
         _homepageSheetViewModel = StateObject(wrappedValue: HomepageSheetViewModel(appProtocolHandler: objectGraph.appProtocolHandler,
@@ -72,6 +80,11 @@ struct LoggedInContentView: View {
                                     },
                                     onUpgrade: {
                                         homepageSheetViewModel.updateState(sheet: .proUpgrade, state: true)
+                                    },
+                                    onSelect: {
+                                        homepageSheetViewModel.updateState(sheet: .publicCompetitionDetails,
+                                                                           state: true,
+                                                                           contextData: competition)
                                     }
                                 )
                                 .fwfCard()
@@ -104,6 +117,13 @@ struct LoggedInContentView: View {
                     .padding(.top, 8)
                     .sheet(isPresented: $homepageSheetViewModel.shouldShowSheet, onDismiss: {
                         homepageSheetViewModel.dismissCurrentSheet()
+                        // Open the create wizard only once the detail sheet has fully
+                        // dismissed — presenting it while the sheet animates out gets
+                        // dropped by SwiftUI.
+                        if shouldShowCreateAfterDetail {
+                            shouldShowCreateAfterDetail = false
+                            homepageSheetViewModel.updateState(sheet: .createCompetition, state: true)
+                        }
                     }, content: {
                         switch homepageSheetViewModel.sheetToShow {
                         case .createCompetition:
@@ -119,7 +139,17 @@ struct LoggedInContentView: View {
                             if let competitionOverview = homepageSheetViewModel.sheetContextData as? CompetitionOverview {
                                 CompetitionDetailView(competitionOverview: competitionOverview,
                                                       homepageSheetViewModel: homepageSheetViewModel,
-                                                      objectGraph: objectGraph)
+                                                      objectGraph: objectGraph,
+                                                      onRematch: { shouldShowCreateAfterDetail = true })
+                            } else {
+                                Text("Error showing competition details")
+                            }
+                        case .publicCompetitionDetails:
+                            if let publicCompetition = homepageSheetViewModel.sheetContextData as? PublicCompetition {
+                                PublicCompetitionDetailView(competition: publicCompetition,
+                                                            isUserPro: homepageViewModel.isUserPro,
+                                                            homepageSheetViewModel: homepageSheetViewModel,
+                                                            objectGraph: objectGraph)
                             } else {
                                 Text("Error showing competition details")
                             }
@@ -176,11 +206,19 @@ struct LoggedInContentView: View {
             isPresented: Binding(
                 get: { competitionEndAlertViewModel.currentEndCompetition != nil },
                 set: { if !$0 { competitionEndAlertViewModel.dismissCurrent() } }
-            )
+            ),
+            onDismiss: {
+                // Open the create wizard only once the end cover has fully dismissed —
+                // presenting it while the cover animates out gets dropped by SwiftUI.
+                if shouldShowCreateAfterEnd {
+                    shouldShowCreateAfterEnd = false
+                    homepageSheetViewModel.updateState(sheet: .createCompetition, state: true)
+                }
+            }
         ) {
             CompetitionEndView(
                 viewModel: competitionEndAlertViewModel,
-                homepageSheetViewModel: homepageSheetViewModel
+                onRematch: { shouldShowCreateAfterEnd = true }
             )
         }
     }

--- a/Clients/iOS/FitWithFriends/UITests/CompetitionEndedAlertTests.swift
+++ b/Clients/iOS/FitWithFriends/UITests/CompetitionEndedAlertTests.swift
@@ -43,6 +43,27 @@ final class CompetitionEndedAlertTests: FWFUITestBase {
         XCTAssertFalse(endScreen.waitForExistence(timeout: 5))
     }
 
+    func testRematchOpensCreateWizard() throws {
+        let competitionId = try createTestCompetition(name: "Rematch Competition")
+        try setCompetitionArchived(competitionId: competitionId, userPoints: 500)
+
+        launchApp(loggedIn: true)
+
+        XCTAssertTrue(homeScreen.waitForExistence(timeout: 30))
+        XCTAssertTrue(endScreen.waitForExistence(timeout: 30))
+
+        // Tapping the rematch / new-competition CTA must dismiss the end cover AND
+        // open the create wizard (the bug: the cover dismissed but nothing followed).
+        let rematchButton = app.buttons["competitionEndRematchButton"]
+        XCTAssertTrue(rematchButton.waitForExistence(timeout: 5))
+        rematchButton.tap()
+
+        XCTAssertTrue(endScreen.waitForNonExistence(timeout: 5))
+        XCTAssertTrue(app.otherElements["createWizard"].waitForExistence(timeout: 10))
+
+        takeScreenshot(name: "12_RematchCreateWizard")
+    }
+
     func testProcessingResultsCompetitionDoesNotShowAlert() throws {
         try createTestCompetition(name: "Still Processing")
 

--- a/Clients/iOS/FitWithFriends/UITests/CompetitionTests.swift
+++ b/Clients/iOS/FitWithFriends/UITests/CompetitionTests.swift
@@ -116,6 +116,38 @@ final class CompetitionTests: FWFUITestBase {
         takeScreenshot(name: "11_CompletedCompetitionDetail")
     }
 
+    func testRematchFromCompletedDetailOpensCreateWizard() throws {
+        let competitionId = try createTestCompetition(name: "Rematch Detail Comp")
+
+        // Shift the window into the past so the competition is completed (shows the rematch CTA).
+        let start = Date(timeIntervalSinceNow: -14 * 24 * 60 * 60)
+        let end = Date(timeIntervalSinceNow: -1 * 24 * 60 * 60)
+        try setCompetitionDates(competitionId: competitionId, start: start, end: end)
+        try seedCompetitionWithUsers(competitionId: competitionId)
+
+        launchApp(loggedIn: true)
+        XCTAssertTrue(homeScreen.waitForExistence(timeout: 10))
+
+        let drawer = app.buttons["competitionDrawer_Completed"]
+        XCTAssertTrue(drawer.waitForExistence(timeout: 15))
+        drawer.tap()
+
+        let row = app.staticTexts["Rematch Detail Comp"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
+
+        XCTAssertTrue(competitionDetailScreen.waitForExistence(timeout: 5))
+
+        // Tapping rematch must dismiss the detail sheet AND open the create wizard
+        // (the bug: the sheet dismissed but nothing followed).
+        let rematchButton = app.buttons["competitionDetailRematchButton"]
+        XCTAssertTrue(rematchButton.waitForExistence(timeout: 5))
+        rematchButton.tap()
+
+        XCTAssertTrue(competitionDetailScreen.waitForNonExistence(timeout: 5))
+        XCTAssertTrue(createWizard.waitForExistence(timeout: 10))
+    }
+
     func testScoringRulesSheetOpensFromDetail() throws {
         try createTestCompetition(name: "Rules Sheet Test")
 

--- a/Clients/iOS/FitWithFriends/UITests/PublicCompetitionTests.swift
+++ b/Clients/iOS/FitWithFriends/UITests/PublicCompetitionTests.swift
@@ -110,4 +110,78 @@ final class PublicCompetitionTests: FWFUITestBase {
         takeScreenshot(name: "09_JoinedPublicCompetition")
     }
 
+    /// End-to-end: a Pro user discovers a public competition they have not joined, taps the
+    /// card to preview its live leaderboard + scoring rules (served by the non-member
+    /// publicOverview endpoint), then joins from the preview and sees it land in their
+    /// active competitions.
+    func testPublicCompetitionDetailPreviewAndJoinEndToEnd() throws {
+        let competitionId = try createPublicCompetition(name: "Preview & Join Challenge")
+
+        // Seed the competition with members + activity so the preview leaderboard has real data
+        try seedCompetitionWithUsers(competitionId: competitionId)
+
+        // Backend must see the user as Pro for the join to succeed
+        try makeUserPro()
+
+        // App must see the user as Pro (drives the Join vs Upgrade button in UI tests)
+        launchApp(loggedIn: true, isPro: true)
+
+        XCTAssertTrue(app.otherElements["homeScreen"].waitForExistence(timeout: 10))
+
+        // The card appears in the Public Competitions section with the details affordance
+        XCTAssertTrue(app.staticTexts["Preview & Join Challenge"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["View leaderboard & scoring"].waitForExistence(timeout: 5))
+
+        // Tapping the card opens the preview sheet
+        app.staticTexts["Preview & Join Challenge"].firstMatch.tap()
+        XCTAssertTrue(app.staticTexts["publicCompetitionDetailScreen"].waitForExistence(timeout: 10))
+
+        // The live leaderboard loaded from the publicOverview endpoint with the seeded members
+        XCTAssertTrue(app.otherElements["publicCompetitionLeaderboard"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Leaderboard"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Alice Chen"].waitForExistence(timeout: 10))
+
+        takeScreenshot(name: "10_PublicCompetitionDetail")
+
+        // The scoring rules sheet opens from the detail header
+        let helpButton = app.buttons["scoringRulesButton"]
+        XCTAssertTrue(helpButton.waitForExistence(timeout: 5))
+        helpButton.tap()
+        XCTAssertTrue(app.staticTexts["HOW SCORING WORKS"].waitForExistence(timeout: 5))
+        app.buttons["Close"].firstMatch.tap()
+        XCTAssertTrue(app.staticTexts["HOW SCORING WORKS"].waitForNonExistence(timeout: 5))
+
+        // Join from the preview
+        let joinButton = app.buttons["publicCompetitionJoinButton"]
+        XCTAssertTrue(joinButton.waitForExistence(timeout: 5))
+        joinButton.tap()
+
+        // The preview dismisses and the now-joined competition appears in the active group
+        XCTAssertTrue(app.staticTexts["publicCompetitionDetailScreen"].waitForNonExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Active now"].waitForExistence(timeout: 15))
+        XCTAssertTrue(app.staticTexts["Preview & Join Challenge"].waitForExistence(timeout: 15))
+    }
+
+    /// A non-Pro user can still open the preview, but the join CTA is replaced by an
+    /// Upgrade to Pro action.
+    func testPublicCompetitionDetailShowsUpgradeForNonPro() throws {
+        let competitionId = try createPublicCompetition(name: "Locked Preview Challenge")
+        try seedCompetitionWithUsers(competitionId: competitionId)
+
+        // Non-pro user (no makeUserPro, no isPro launch flag)
+        launchApp(loggedIn: true)
+
+        XCTAssertTrue(app.otherElements["homeScreen"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Locked Preview Challenge"].waitForExistence(timeout: 10))
+
+        app.staticTexts["Locked Preview Challenge"].firstMatch.tap()
+        XCTAssertTrue(app.staticTexts["publicCompetitionDetailScreen"].waitForExistence(timeout: 10))
+
+        // Non-pro users see the upgrade CTA instead of a join button
+        XCTAssertTrue(app.buttons["publicCompetitionUpgradeButton"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["publicCompetitionJoinButton"].exists)
+
+        takeScreenshot(name: "11_PublicCompetitionDetailUpgrade")
+    }
+
 }

--- a/Clients/iOS/FitWithFriends/UnitTests/CompetitionManagerTests.swift
+++ b/Clients/iOS/FitWithFriends/UnitTests/CompetitionManagerTests.swift
@@ -133,6 +133,24 @@ final class CompetitionManagerTests: XCTestCase {
         XCTAssertEqual(result.dailySummaries.count, 1)
     }
 
+    func test_getPublicCompetitionOverview_shouldCallService() async throws {
+        // Arrange
+        let competitionId = UUID()
+        let expectedOverview = CompetitionOverview(id: competitionId,
+                                                   name: "Public Comp",
+                                                   isPublic: true)
+        mockCompetitionService.return_getPublicCompetitionOverview = expectedOverview
+
+        // Act
+        let result = try await competitionManager.getPublicCompetitionOverview(competitionId: competitionId)
+
+        // Assert
+        XCTAssertEqual(mockCompetitionService.getPublicCompetitionOverviewCallCount, 1)
+        XCTAssertEqual(mockCompetitionService.param_getPublicCompetitionOverview_competitionId, competitionId)
+        XCTAssertEqual(result.competitionId, competitionId)
+        XCTAssertTrue(result.isPublic)
+    }
+
     func XCTAssertThrowsErrorAsync<T>(_ expression: @autoclosure () async throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line, _ errorHandler: (Error) -> Void) async {
         do {
             _ = try await expression()

--- a/WebService/FitWithFriends/routes/competitions.ts
+++ b/WebService/FitWithFriends/routes/competitions.ts
@@ -426,6 +426,67 @@ router.get('/:competitionId/overview', function (req, res) {
         });
 });
 
+// Returns the overview (scoring rules + live standings) for a PUBLIC competition.
+// Unlike /overview, this does NOT require the caller to be a member, so the user can
+// preview a public competition before deciding to join. Private competitions are never
+// exposed here - the competition must have is_public = true.
+//
+// Expects a query param with the user's current timezone
+router.get('/:competitionId/publicOverview', function (req, res) {
+    const timezoneParam = req.query['timezone']?.toString();
+    const competitionId: string = req.params.competitionId;
+    if (!timezoneParam || !allIANATimezones.includes(timezoneParam)) {
+        handleError(null, 400, 'Invalid timezone query param: ' + timezoneParam, res);
+        return;
+    }
+
+    const userId = res.locals.oauth.token.user.id;
+    Promise.all([
+        UserQueries.getUsersInCompetition({ competitionId }),
+        CompetitionQueries.getCompetition({ competitionId })
+    ])
+        .then(([usersCompetitionsResult, competitionsResult]) => {
+            if (!competitionsResult.length) {
+                handleError(null, 404, 'Could not find competition info', res);
+                return;
+            }
+
+            // Only public competitions can be previewed by non-members. Treat private
+            // competitions as not found so we never leak their existence or details.
+            const competitionInfo = competitionsResult[0];
+            if (!competitionInfo.is_public) {
+                handleError(null, 404, 'Could not find competition info', res);
+                return;
+            }
+
+            const isUserAdmin = userId === convertBufferToUserId(competitionInfo.admin_user_id);
+
+            getCompetitionStandings(competitionInfo, usersCompetitionsResult, timezoneParam)
+                .then(userPoints => {
+                    const parsedRules = parseScoringRules(competitionInfo.scoring_rules);
+                    res.json({
+                        'competitionId': competitionInfo.competition_id,
+                        'competitionName': competitionInfo.display_name,
+                        'competitionStart': competitionInfo.start_date,
+                        'competitionEnd': competitionInfo.end_date,
+                        'competitionState': competitionInfo.state,
+                        'isCompetitionProcessingResults': competitionInfo.state === CompetitionState.ProcessingResults,
+                        'isUserAdmin': isUserAdmin,
+                        'isPublic': competitionInfo.is_public,
+                        'scoringRules': competitionInfo.scoring_rules ?? { kind: 'rings' },
+                        'scoringUnit': getScoringUnit(parsedRules),
+                        'currentResults': Object.values(userPoints)
+                    });
+                })
+                .catch(error => {
+                    handleError(error, 500, 'Error calculating results', res);
+                });
+        })
+        .catch(error => {
+            handleError(error, 500, 'Error getting competition info', res);
+        });
+});
+
 // Returns the daily activity summaries and points for a specific user within a competition
 // Both the requesting user and the target user must be members of the competition
 // Only returns data within the competition's date range

--- a/WebService/FitWithFriends/test/routes/competitions/getPublicCompetitionOverview.test.ts
+++ b/WebService/FitWithFriends/test/routes/competitions/getPublicCompetitionOverview.test.ts
@@ -1,0 +1,175 @@
+import * as TestSQL from '../../testUtilities/sql/testQueries.queries';
+import * as RequestUtilities from '../../testUtilities/testRequestUtilities';
+import * as AuthUtilities from '../../testUtilities/testAuthUtilities';
+import { convertUserIdToBuffer } from '../../../utilities/userHelpers';
+import { ICreateCompetitionParams } from '../../../sql/competitions.queries';
+
+/*
+    Tests the /competitions/:competitionId/publicOverview route, which lets a user
+    preview a PUBLIC competition (scoring rules + live standings) WITHOUT being a
+    member. Private competitions must never be exposed here.
+*/
+
+// The admin/member user that owns the competitions created in setup
+const adminUserId = Math.random().toString().slice(2, 8);
+const adminUserName = 'Admin User';
+
+// A second user who is NOT a member of any competition - represents someone
+// browsing public competitions before joining.
+const nonMemberUserId = Math.random().toString().slice(2, 8);
+const nonMemberUserName = 'Browser Person';
+
+const now = new Date();
+
+var usersToCleanup: string[] = [];
+var competitionsToCleanup: string[] = [];
+
+async function createUser(userId: string, userName: string) {
+    await TestSQL.createUser({
+        userId: convertUserIdToBuffer(userId),
+        firstName: userName.split(' ')[0],
+        lastName: userName.split(' ')[1],
+        maxActiveCompetitions: 10,
+        isPro: false,
+        createdDate: new Date()
+    });
+    usersToCleanup.push(userId);
+}
+
+beforeEach(async () => {
+    try {
+        await createUser(adminUserId, adminUserName);
+        await createUser(nonMemberUserId, nonMemberUserName);
+    } catch (error) {
+        console.log('Test setup failed: ' + error);
+        throw error;
+    }
+});
+
+afterEach(async () => {
+    await Promise.all(usersToCleanup.map(userId => TestSQL.clearDataForUser({ userId: convertUserIdToBuffer(userId) })));
+    await Promise.all(competitionsToCleanup.map(competitionId => TestSQL.clearDataForCompetition({ competitionId })));
+
+    usersToCleanup = [];
+    competitionsToCleanup = [];
+});
+
+async function createPublicCompetitionWithAdmin(): Promise<string> {
+    const competitionId = crypto.randomUUID();
+    await TestSQL.createPublicCompetition({
+        competitionId,
+        displayName: 'Public Test Competition',
+        startDate: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 3), // 3 days ago
+        endDate: new Date(now.getTime() + 1000 * 60 * 60 * 24 * 4), // 4 days from now
+        adminUserId: convertUserIdToBuffer(adminUserId),
+        accessToken: 'unused',
+        ianaTimezone: 'America/New_York'
+    });
+    competitionsToCleanup.push(competitionId);
+
+    await TestSQL.addUserToCompetition({
+        competitionId,
+        userId: convertUserIdToBuffer(adminUserId)
+    });
+
+    return competitionId;
+}
+
+test('Get public overview: non-member can view a public competition', async () => {
+    const competitionId = await createPublicCompetitionWithAdmin();
+
+    // Give the member some activity so the leaderboard has a real score
+    const expectedTodayScore = (100 * 250.0 / 500.0) + (100 * 30.0 / 60.0) + (100 * 6.0 / 12.0);
+    await TestSQL.insertActivitySummary({
+        userId: convertUserIdToBuffer(adminUserId),
+        date: now,
+        caloriesBurned: 250,
+        caloriesGoal: 500,
+        exerciseTime: 30,
+        exerciseTimeGoal: 60,
+        standTime: 6,
+        standTimeGoal: 12,
+    });
+
+    // The non-member requests the public overview
+    const accessToken = await AuthUtilities.getAccessTokenForUser(nonMemberUserId);
+    const response = await RequestUtilities.makeGetRequest(`competitions/${competitionId}/publicOverview?timezone=America/New_York`, accessToken);
+
+    expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 200 }));
+    expect(response.data.isPublic).toBe(true);
+    expect(response.data.competitionName).toBe('Public Test Competition');
+    expect(response.data.scoringRules).toEqual({ kind: 'rings' });
+    expect(response.data.scoringUnit).toBe('points');
+
+    // The non-member is not an admin and isn't in the standings
+    expect(response.data.isUserAdmin).toBe(false);
+    expect(response.data).toHaveProperty('currentResults');
+    expect(response.data.currentResults.length).toBe(1);
+
+    const memberResult = response.data.currentResults.find((r: any) => r.userId === adminUserId);
+    expect(memberResult).not.toBeUndefined();
+    expect(memberResult.pointsToday).toBeCloseTo(expectedTodayScore);
+    expect(response.data.currentResults.find((r: any) => r.userId === nonMemberUserId)).toBeUndefined();
+});
+
+test('Get public overview: admin viewing their own public competition is flagged as admin', async () => {
+    const competitionId = await createPublicCompetitionWithAdmin();
+
+    const accessToken = await AuthUtilities.getAccessTokenForUser(adminUserId);
+    const response = await RequestUtilities.makeGetRequest(`competitions/${competitionId}/publicOverview?timezone=America/New_York`, accessToken);
+
+    expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 200 }));
+    expect(response.data.isUserAdmin).toBe(true);
+});
+
+test('Get public overview: private competition is not exposed (returns 404)', async () => {
+    // Create a PRIVATE competition owned by the admin
+    const privateCompetitionInfo: ICreateCompetitionParams = {
+        competitionId: crypto.randomUUID(),
+        adminUserId: convertUserIdToBuffer(adminUserId),
+        displayName: 'Private Competition',
+        startDate: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 3),
+        endDate: new Date(now.getTime() + 1000 * 60 * 60 * 24 * 3),
+        accessToken: '1234',
+        ianaTimezone: 'America/New_York'
+    };
+    await TestSQL.createCompetition(privateCompetitionInfo);
+    competitionsToCleanup.push(privateCompetitionInfo.competitionId);
+    await TestSQL.addUserToCompetition({
+        competitionId: privateCompetitionInfo.competitionId,
+        userId: convertUserIdToBuffer(adminUserId)
+    });
+
+    // Even the admin/member cannot fetch a private competition via the public route
+    const accessToken = await AuthUtilities.getAccessTokenForUser(adminUserId);
+    const response = await RequestUtilities.makeGetRequest(`competitions/${privateCompetitionInfo.competitionId}/publicOverview?timezone=America/New_York`, accessToken);
+
+    expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 404 }));
+    expect(response.data.context).toContain('Could not find competition info');
+});
+
+test('Get public overview: competition does not exist returns 404', async () => {
+    const accessToken = await AuthUtilities.getAccessTokenForUser(nonMemberUserId);
+    const response = await RequestUtilities.makeGetRequest(`competitions/${crypto.randomUUID()}/publicOverview?timezone=America/New_York`, accessToken);
+
+    expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 404 }));
+    expect(response.data.context).toContain('Could not find competition info');
+});
+
+test('Get public overview: invalid timezone returns 400', async () => {
+    const competitionId = await createPublicCompetitionWithAdmin();
+
+    const accessToken = await AuthUtilities.getAccessTokenForUser(nonMemberUserId);
+    const response = await RequestUtilities.makeGetRequest(`competitions/${competitionId}/publicOverview?timezone=INVALIDTIMEZONE`, accessToken);
+
+    expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 400 }));
+    expect(response.data.context).toContain('Invalid timezone query param');
+});
+
+test('Get public overview: missing access token returns 400', async () => {
+    const competitionId = await createPublicCompetitionWithAdmin();
+
+    const response = await RequestUtilities.makeGetRequest(`competitions/${competitionId}/publicOverview?timezone=America/New_York`);
+
+    expect({ status: response.status, body: response.data }).toEqual(expect.objectContaining({ status: 400 }));
+});


### PR DESCRIPTION
## Overview

A batch of build feedback fixes plus one new feature, all in the competition flows.

## Create-competition bug fixes
- **Dark-mode washout:** selected segmented controls, metric cards, and chips filled their pill with `Color("Ink")` (near-white in dark mode) but used hardcoded white text, so the text washed out. Since `Bg` is the inverse of `Ink` in both appearances, selected foregrounds now use `Color("Bg")` for correct contrast in light and dark.
- **Removed the "visual reference only" slider:** the daily-target slider did nothing — its value was never sent to the server. Removed the card and the now-unused `dailyTarget` property.
- **Corrected stale Pro price:** `$19.99/year` → `$2.99/mo` in the create flow callout/button and in Settings, matching the actual monthly product and `ProUpgradeView`.

## New feature — preview a public competition before joining
Previously the public competition card only had Join/Upgrade buttons; there was no way to see details before joining, and the existing `/overview` endpoint is member-gated.
- **Backend:** new `GET /competitions/:competitionId/publicOverview` returns scoring rules + live standings **without** requiring membership. Private competitions return 404 so they can't be probed. Reuses the existing `getCompetition`/`getUsersInCompetition` queries and `getCompetitionStandings` helper (no new SQL).
- **iOS:** `PublicCompetitionDetailView` loads the overview and shows the header, a read-only leaderboard, and the scoring-rules sheet, with a Join (Pro) / Upgrade (non-Pro) CTA. The public competition card is now tappable to open it, routed through a new `.publicCompetitionDetails` sheet case.

## Other fixes
- **Scoring-rules sheet padding:** bumped the "How scoring works" header top padding (4 → 24) so it no longer sits cramped against the sheet's drag indicator.
- **Rematch CTA did nothing:** on both the competition-end cover and the completed-competition detail view, the rematch button dismissed but never opened the create wizard — it presented the wizard on a `0.4s` timer that raced the dismissal animation, and SwiftUI silently dropped the presentation. Both now hand off via the cover/sheet `onDismiss`, which fires after dismissal completes.

## Tests
- **Backend:** `getPublicCompetitionOverview.test.ts` — non-member access, private→404, missing→404, bad timezone→400, admin flag. All existing overview/public tests still pass.
- **iOS unit:** `CompetitionManager.getPublicCompetitionOverview` delegation.
- **iOS UI:** public competition preview + join end-to-end, non-Pro upgrade CTA in the preview, and rematch-opens-create-wizard for both the end cover and the completed detail view.

## Reviewer notes
- The new backend endpoint deliberately treats private competitions as 404 (not 403) to avoid leaking their existence.
- `CompetitionEndView` no longer depends on `HomepageSheetViewModel` (removed the now-dead property); `CompetitionDetailView` keeps it (still needed by its view model) and gained a defaulted `onRematch` parameter.
- Verified locally: iOS app builds, backend type-checks, and the new/affected unit + UI tests pass against the local test backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)