### PR TITLE
Redesign competition-done sheet as Podium results + working share card

### DIFF
--- a/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Home/CompetitionEndAlertViewModel.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Home/CompetitionEndAlertViewModel.swift
@@ -76,7 +76,10 @@ class CompetitionEndAlertViewModel: ObservableObject {
         markNotificationsSeen(for: next.competitionId)
 
         let position = userPosition(in: next) ?? Int.max
-        let willShowConfetti = position <= 3
+        // The podium sheet (Direction B) celebrates a win only — confetti fires
+        // exclusively when the user finishes 1st. Podium finishes 2nd/3rd are
+        // still honored visually by the podium, but without confetti.
+        let willShowConfetti = position == 1
         if willShowConfetti {
             // Start confetti first so particles are already in motion when the
             // sheet appears, keeping them visible to the user.
@@ -130,6 +133,138 @@ class CompetitionEndAlertViewModel: ObservableObject {
         guard let competition = currentEndCompetition,
               let position = userPosition(in: competition) else { return nil }
         return CompetitionOverviewViewModel.ordinal(position)
+    }
+
+    // MARK: - Podium sheet (Direction B) presentation model
+
+    /// Three-way outcome that drives the podium sheet's gradient, confetti, and copy.
+    /// `won` (1st) is the loud, celebratory state; `last` (finished dead last) is the
+    /// gracious state; everyone in between is `mid`.
+    enum EndOutcome {
+        case won
+        case mid
+        case last
+    }
+
+    var endOutcome: EndOutcome {
+        guard let competition = currentEndCompetition,
+              let position = userPosition(in: competition) else {
+            return .mid
+        }
+        if position == 1 { return .won }
+        if position == competition.currentResults.count { return .last }
+        return .mid
+    }
+
+    /// The current user's 1-based final placement, or `nil` when they weren't in the results.
+    var userPlacement: Int? {
+        guard let competition = currentEndCompetition else { return nil }
+        return userPosition(in: competition)
+    }
+
+    /// Whether the user landed on the podium (top 3) — drives the highlighted pedestal.
+    var isUserOnPodium: Bool {
+        guard let placement = userPlacement else { return false }
+        return placement <= 3
+    }
+
+    /// Total number of competitors.
+    var memberCount: Int {
+        currentEndCompetition?.currentResults.count ?? 0
+    }
+
+    /// Italic serif accent rendered on the second line of the headline.
+    var headlineAccent: String {
+        switch endOutcome {
+        case .won:  return "You won."
+        case .mid:  return "Strong showing."
+        case .last: return "Every day counts."
+        }
+    }
+
+    /// One-line subline under the "You finished" title.
+    var outcomeSubline: String {
+        switch endOutcome {
+        case .won:
+            return "First place is yours. Nobody closed more."
+        case .mid:
+            return "Right in the hunt — a couple of big days from the podium."
+        case .last:
+            return "You logged \(competitionDayCount) days and never quit. That's the whole point."
+        }
+    }
+
+    /// Whole calendar days the competition spanned (inclusive), floored at 1. Derived from the
+    /// date range so it's available immediately, without waiting on the daily-summary load.
+    private var competitionDayCount: Int {
+        guard let competition = currentEndCompetition else { return 0 }
+        let days = Calendar.current.dateComponents([.day], from: competition.startDate, to: competition.endDate).day ?? 0
+        return max(1, days)
+    }
+
+    /// One podium slot for the top-3 visualization.
+    struct PodiumEntry: Identifiable {
+        let id = UUID()
+        let position: Int
+        let firstName: String
+        let displayName: String
+        let points: Double?
+        let isCurrentUser: Bool
+    }
+
+    /// The competition's actual top three, ordered 1 → 3. Always the real top 3 — when the user
+    /// finished mid-pack or last they won't appear here, only in the "You finished" row below.
+    var podiumEntries: [PodiumEntry] {
+        guard let competition = currentEndCompetition else { return [] }
+        let userId = authenticationManager.loggedInUserId
+        return competition.currentResults.sorted().prefix(3).enumerated().map { index, points in
+            PodiumEntry(position: index + 1,
+                        firstName: points.firstName,
+                        displayName: points.displayName,
+                        points: points.totalPoints,
+                        isCurrentUser: points.userId == userId)
+        }
+    }
+
+    /// The user's total score, formatted compactly without a unit suffix (the row shows a
+    /// separate "PTS"/"STEPS"/… tag beside it).
+    var userScoreValue: String {
+        guard let competition = currentEndCompetition,
+              let row = competition.currentResults.first(where: { $0.userId == authenticationManager.loggedInUserId }),
+              let total = row.totalPoints else { return "—" }
+        return ScoringValueFormatter.formatCompact(total, unit: competition.scoringUnit)
+    }
+
+    /// App Store listing for Fit with Friends — the payload attached to a shared result so
+    /// recipients can download the app.
+    static let appStoreURL = "https://apps.apple.com/app/id6451087375"
+
+    /// Hype-friend result sentence that accompanies the shared result card. Trophy emoji is
+    /// earned only on a win, matching the rest of the design's voice.
+    var shareText: String {
+        guard let competition = currentEndCompetition, let ordinal = userPositionOrdinal else {
+            return "Check out my results on Fit with Friends!"
+        }
+        switch endOutcome {
+        case .won:
+            return "🏆 I finished \(ordinal) of \(memberCount) in \(competition.competitionName) on Fit with Friends!"
+        case .mid:
+            return "I finished \(ordinal) of \(memberCount) in \(competition.competitionName) on Fit with Friends. 💪"
+        case .last:
+            return "I logged \(competitionDayCount) days in \(competition.competitionName) on Fit with Friends and never quit. 💪"
+        }
+    }
+
+    /// Short, uppercase unit tag shown beside the user's score ("PTS", "STEPS", "KCAL", …).
+    var unitTagText: String {
+        guard let competition = currentEndCompetition else { return "PTS" }
+        switch competition.scoringUnit {
+        case .points:  return "PTS"
+        case .steps:   return "STEPS"
+        case .kcal:    return "KCAL"
+        case .minutes: return "MIN"
+        case .meters:  return Locale.current.measurementSystem == .metric ? "KM" : "MI"
+        }
     }
 
     /// Number of days where the user closed all three Apple Activity rings.

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionEndView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionEndView.swift
@@ -2,387 +2,542 @@
 //  CompetitionEndView.swift
 //  FitWithFriends
 //
-//  Full-screen variant-aware celebration / consolation screen shown when a
-//  competition ends. Replaces the legacy `.alert(...)`. Five variants:
-//    1st (won) · 2nd (silver) · 3rd (bronze) · 4th–2nd-from-last (midPack) · last
-//  The lower the finish, the more the screen shrinks the rank chrome and grows
-//  personal stats.
+//  The "Competition Done" results sheet (design Direction B — "Podium"). Shown as a
+//  bottom sheet over the home feed the moment a competition ends (or when the user
+//  taps a finished competition). It names the competition that finished, celebrates a
+//  win with a brand-gradient header + confetti, visualizes the top-3 podium, and
+//  highlights the user's "You finished Nth of N" row. The same layout adapts to all
+//  three outcomes — loud on a win, paper-calm and gracious on a mid/last finish.
+//
+//  Tapping "Share" renders a standalone result card (CompetitionShareCardView) to an
+//  image via ImageRenderer and offers it — plus a hype sentence and the App Store link —
+//  through the system share sheet.
 //
 
+import ConfettiSwiftUI
 import SwiftUI
 
 struct CompetitionEndView: View {
     @ObservedObject var viewModel: CompetitionEndAlertViewModel
-    /// Invoked when the user taps the rematch / new-competition CTA. The parent is
-    /// responsible for opening the create wizard once this cover has fully dismissed —
-    /// presenting it here (while the cover is still animating out) gets dropped by SwiftUI.
+    /// Invoked when the user taps the rematch CTA. The parent is responsible for opening the
+    /// create wizard once this sheet has fully dismissed — presenting it here (while the sheet
+    /// is still animating out) gets dropped by SwiftUI.
     var onRematch: () -> Void = {}
-    @Environment(\.dismiss) private var dismiss
+    /// Invoked when the user taps "Full standings" — the parent routes to the Competition
+    /// Detail screen (which renders the full leaderboard) after this sheet dismisses.
+    var onViewStandings: (CompetitionOverview) -> Void = { _ in }
 
-    @State private var showingShare: Bool = false
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.displayScale) private var displayScale
+
+    @State private var showingShare = false
+    @State private var shareItems: [Any] = []
+    @State private var confettiTrigger = 0
+
+    private var won: Bool { viewModel.endOutcome == .won }
 
     var body: some View {
-        ZStack {
-            backgroundColor.ignoresSafeArea()
-
-            ScrollView {
-                VStack(spacing: 20) {
-                    FWFTag(text: "Competition complete",
-                           color: Color("Brand"),
-                           background: Color("BrandSoft"))
-                        .accessibilityIdentifier("competitionEndScreen")
-                        .padding(.top, 24)
-
-                    headline
-                        .padding(.horizontal, 22)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .multilineTextAlignment(.center)
-
-                    subParagraph
-                        .padding(.horizontal, 22)
-
-                    hero
-                        .padding(.horizontal, 16)
-
-                    statsGrid
-                        .padding(.horizontal, 16)
-
-                    actionRow
-                        .padding(.horizontal, 16)
-                        .padding(.bottom, 28)
-                }
-                .frame(maxWidth: .infinity)
-            }
-
-            VStack {
-                HStack {
-                    Spacer()
-                    Button {
-                        viewModel.dismissCurrent()
-                        dismiss()
-                    } label: {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(Color("Ink"))
-                            .frame(width: 36, height: 36)
-                            .background(Circle().fill(Color("Surface")))
-                            .shadow(color: Color("Ink").opacity(0.1), radius: 6, x: 0, y: 2)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("competitionEndDismiss")
-                    .accessibilityLabel("OK")
-                    .padding(16)
-                }
-                Spacer()
+        ScrollView {
+            VStack(spacing: 0) {
+                headerCap
+                bodyRegion
+                    .padding(.top, -12)
             }
         }
+        .scrollBounceBehavior(.basedOnSize)
+        .background(Color("Surface"))
+        .presentationDetents([.height(580), .large])
+        .presentationDragIndicator(.hidden)
+        .presentationCornerRadius(30)
         .sheet(isPresented: $showingShare) {
-            // Reuses the system share sheet with a simple plain-text composition.
-            if let text = shareText, let url = URL(string: text) ?? URL(string: "https://example.com") {
-                ShareSheet(url: url)
+            ShareSheet(activityItems: shareItems)
+        }
+    }
+
+    private func dismissSheet() {
+        viewModel.dismissCurrent()
+        dismiss()
+    }
+
+    // MARK: - Header cap
+
+    private var headerCap: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            grabHandle
+
+            VStack(alignment: .leading, spacing: 9) {
+                eyebrow
+                headline
             }
-        }
-    }
-
-    // MARK: - Variant text
-
-    private var backgroundColor: Color {
-        switch viewModel.endVariant {
-        case .won:     return Color("Sun").opacity(0.18)
-        case .silver:  return Color("Bg")
-        case .bronze:  return Color("Bg")
-        case .midPack: return Color("Sun").opacity(0.10)
-        case .last:    return Color("Bg")
-        }
-    }
-
-    @ViewBuilder
-    private var headline: some View {
-        switch viewModel.endVariant {
-        case .won:
-            FWFDisplay(parts: [("You ", false), ("won", true), (".", false)],
-                       size: 56, italicColor: Color("Brand"), alignment: .center)
-        case .silver:
-            FWFDisplay(parts: [("So ", false), ("close.", true), (" Silver.", false)],
-                       size: 48, italicColor: Color("Silver"), alignment: .center)
-        case .bronze:
-            FWFDisplay(parts: [("Bronze. ", false), ("The podium.", true)],
-                       size: 48, italicColor: Color("Bronze"), alignment: .center)
-        case .midPack:
-            FWFDisplay(parts: [("You showed up. ", false), ("Every day.", true)],
-                       size: 44, italicColor: Color("Sun"), alignment: .center)
-        case .last:
-            FWFDisplay(parts: [("Tough one. But you ", false), ("showed up", true), (".", false)],
-                       size: 44, italicColor: Color("Brand"), alignment: .center)
-        }
-    }
-
-    private var subParagraph: some View {
-        let text: String
-        switch viewModel.endVariant {
-        case .won:
-            text = "You closed all three rings on \(viewModel.daysClosedAllRings) of \(viewModel.dailySummaries.count) days — your most consistent comp yet."
-        case .silver:
-            if let gap = viewModel.gapToFirst, let winner = viewModel.winner {
-                text = "\(gap) behind \(winner.firstName). She had a big day — without it, this was yours."
-            } else {
-                text = "An incredibly close finish."
-            }
-        case .bronze:
-            text = "A solid \(viewModel.dailySummaries.count) days. You beat most of your group, closed all rings \(viewModel.daysClosedAllRings) days."
-        case .midPack:
-            text = "Your best streak yet — \(viewModel.moveRingStreak) consecutive Move closures. The leaderboard says one thing, the chart says you're getting fitter."
-        case .last:
-            text = "Not your week on the leaderboard. That said — here's everything you did right."
-        }
-        return Text(text)
-            .font(.system(size: 15))
-            .foregroundStyle(Color("InkSoft"))
-            .multilineTextAlignment(.center)
-            .fixedSize(horizontal: false, vertical: true)
-    }
-
-    // MARK: - Hero
-
-    @ViewBuilder
-    private var hero: some View {
-        switch viewModel.endVariant {
-        case .won:
-            podium(highlightStep: 1)
-        case .silver:
-            silverHero
-        case .bronze:
-            podium(highlightStep: 3)
-        case .midPack:
-            streakHero
-        case .last:
-            achievementStrip
-        }
-    }
-
-    private func podium(highlightStep: Int) -> some View {
-        // 3-step podium with steps shown in medal colors. The user's avatar sits
-        // on the highlighted step.
-        let me = viewModel.currentEndCompetition?.currentResults
-            .sorted()
-            .first(where: { $0.userId == nil ? false : true })  // any row exists
-        _ = me  // suppress unused warning for previews
-
-        return HStack(alignment: .bottom, spacing: 8) {
-            podiumStep(rank: 2, height: 70, color: Color("Silver"), isMine: highlightStep == 2)
-            podiumStep(rank: 1, height: 96, color: Color("Gold"), isMine: highlightStep == 1)
-            podiumStep(rank: 3, height: 50, color: Color("Bronze"), isMine: highlightStep == 3)
-        }
-        .padding(20)
-        .frame(maxWidth: .infinity)
-        .fwfCard(padding: 0)
-    }
-
-    private func podiumStep(rank: Int, height: CGFloat, color: Color, isMine: Bool) -> some View {
-        VStack(spacing: 6) {
-            if isMine {
-                FWFAvatar(name: "You", size: 36, ring: color)
-            } else {
-                Circle().fill(Color("InkFaint").opacity(0.4)).frame(width: 32, height: 32)
-            }
-            ZStack {
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(color.opacity(0.9))
-                Text("\(rank)")
-                    .font(.system(size: 22, weight: .bold))
-                    .foregroundStyle(.white)
-            }
-            .frame(width: 64, height: height)
-        }
-    }
-
-    private var silverHero: some View {
-        HStack(alignment: .center, spacing: 16) {
-            ZStack {
-                Circle().fill(Color("Silver"))
-                Text("2")
-                    .font(.system(size: 72, weight: .bold))
-                    .foregroundStyle(.white)
-            }
-            .frame(width: 140, height: 140)
-
-            if let winner = viewModel.winner {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Winner")
-                        .font(.system(size: 10.5, weight: .semibold))
-                        .tracking(0.6)
-                        .foregroundStyle(Color("InkMute"))
-                    FWFAvatar(name: winner.displayName, size: 36, ring: Color("Gold"))
-                    Text(winner.displayName)
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(Color("Ink"))
-                    if let total = winner.totalPoints, let competition = viewModel.currentEndCompetition {
-                        Text(ScoringValueFormatter.format(total, unit: competition.scoringUnit))
-                            .font(.system(size: 12))
-                            .foregroundStyle(Color("InkSoft"))
-                    }
-                }
-            }
-        }
-        .padding(20)
-        .frame(maxWidth: .infinity)
-        .fwfCard(padding: 0)
-    }
-
-    private var streakHero: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .firstTextBaseline) {
-                Text("\(viewModel.moveRingStreak)")
-                    .font(.system(size: 64, weight: .bold))
-                    .monospacedDigit()
-                    .foregroundStyle(Color("Sun"))
-                Text("day Move streak")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(Color("InkSoft"))
-            }
-
-            // 12-cell intensity strip
-            let summaries = viewModel.dailySummaries.sorted { $0.date < $1.date }
-            HStack(spacing: 3) {
-                ForEach(Array(summaries.enumerated()), id: \.offset) { _, summary in
-                    let closed = summary.caloriesGoal > 0 && summary.caloriesBurned >= summary.caloriesGoal
-                    RoundedRectangle(cornerRadius: 3, style: .continuous)
-                        .fill(closed ? Color("Sun") : Color("Sun").opacity(0.18))
-                        .frame(height: 18)
-                }
-            }
-
-            Text("Consecutive days you closed your Move ring across this competition.")
-                .font(.system(size: 11))
-                .foregroundStyle(Color("InkMute"))
-        }
-        .fwfCard(padding: 18)
-    }
-
-    private var achievementStrip: some View {
-        VStack(spacing: 10) {
-            achievementCard(icon: "checkmark.seal.fill", color: Color("Brand"),
-                            title: "Logged \(viewModel.dailySummaries.count) of \(viewModel.dailySummaries.count) days",
-                            subtitle: "Perfect attendance — most participants miss 2+ days.")
-            achievementCard(icon: "flame.fill", color: Color("Move"),
-                            title: "Move ring closed \(viewModel.daysClosedAllRings) days",
-                            subtitle: "Days you hit your Move goal during this competition.")
-            if let best = viewModel.bestDay, let competition = viewModel.currentEndCompetition {
-                achievementCard(icon: "arrow.up.right", color: Color("Exercise"),
-                                title: "\(ScoringValueFormatter.format(best.points, unit: competition.scoringUnit)) on \(Self.shortMonthDay(best.date))",
-                                subtitle: "Your highest-effort day in this competition.")
-            }
-        }
-    }
-
-    private static func shortMonthDay(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d"
-        return formatter.string(from: date)
-    }
-
-    private func achievementCard(icon: String, color: Color, title: String, subtitle: String) -> some View {
-        HStack(alignment: .center, spacing: 12) {
-            Image(systemName: icon)
-                .font(.system(size: 18))
-                .foregroundStyle(color)
-                .frame(width: 36, height: 36)
-                .background(Circle().fill(color.opacity(0.18)))
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(Color("Ink"))
-                Text(subtitle)
-                    .font(.system(size: 11))
-                    .foregroundStyle(Color("InkSoft"))
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer()
-        }
-        .fwfCard(padding: 12)
-    }
-
-    // MARK: - Stats grid
-
-    private var statsGrid: some View {
-        LazyVGrid(columns: [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)], spacing: 10) {
-            statCell(label: "Total", value: viewModel.totalDisplay)
-            statCell(label: "Full-ring days",
-                     value: "\(viewModel.daysClosedAllRings) of \(viewModel.dailySummaries.count)")
-            statCell(label: "Move streak",
-                     value: "\(viewModel.moveRingStreak) days",
-                     highlight: viewModel.endVariant == .midPack || viewModel.endVariant == .last)
-            if let best = viewModel.bestDay, let competition = viewModel.currentEndCompetition {
-                statCell(label: "Best day",
-                         value: "\(ScoringValueFormatter.formatCompact(best.points, unit: competition.scoringUnit)) · \(Self.shortMonthDay(best.date))")
-            } else {
-                statCell(label: "Best day", value: "—")
-            }
-        }
-    }
-
-    private func statCell(label: String, value: String, highlight: Bool = false) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(label)
-                .font(.system(size: 11, weight: .semibold))
-                .tracking(0.5)
-                .foregroundStyle(Color("InkMute"))
-            Text(value)
-                .font(.system(size: 18, weight: .bold))
-                .monospacedDigit()
-                .foregroundStyle(highlight ? Color("Sun") : Color("Ink"))
-                .lineLimit(1)
-                .minimumScaleFactor(0.6)
+            .padding(.top, 8)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(highlight ? Color("Sun").opacity(0.14) : Color("Surface"))
+        .padding(.horizontal, 22)
+        .padding(.bottom, 30)
+        .background(headerBackground)
+        .overlay(alignment: .top) {
+            if won {
+                Color.clear
+                    .frame(height: 1)
+                    .confettiCannon(trigger: $confettiTrigger,
+                                    num: 60,
+                                    colors: confettiColors,
+                                    openingAngle: .degrees(40),
+                                    closingAngle: .degrees(140),
+                                    radius: 220)
+            }
+        }
+        .onAppear {
+            guard won, !reduceMotion else { return }
+            confettiTrigger += 1
+        }
+    }
+
+    @ViewBuilder
+    private var headerBackground: some View {
+        if won {
+            LinearGradient(colors: [Color("BrandHi"), Color("Brand")],
+                           startPoint: .topLeading,
+                           endPoint: .bottomTrailing)
+        } else {
+            Color("SurfaceAlt")
+        }
+    }
+
+    private var confettiColors: [Color] {
+        [Color("Move"), Color("Exercise"), Color("Stand"), Color("Gold"), Color("BrandHi")]
+    }
+
+    private var grabHandle: some View {
+        // Tap or drag-down dismisses. We draw the handle ourselves (system indicator is
+        // hidden) so it can carry the win-mode white treatment from the design.
+        Button(action: dismissSheet) {
+            Capsule()
+                .fill((won ? Color.white.opacity(0.6) : Color("InkFaint")).opacity(won ? 1 : 0.7))
+                .frame(width: 38, height: 5)
+                .frame(maxWidth: .infinity)
+                .padding(.top, 10)
+                .padding(.bottom, 2)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("competitionEndDismiss")
+        .accessibilityLabel("Dismiss")
+    }
+
+    private var eyebrow: some View {
+        HStack(spacing: 7) {
+            if won {
+                Image(systemName: "trophy.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+            Text("Final results")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(1.05)
+                .textCase(.uppercase)
+                .foregroundStyle(won ? Color.white.opacity(0.82) : Color("InkSoft"))
+                .accessibilityIdentifier("competitionEndScreen")
+        }
+    }
+
+    private var headline: some View {
+        let name = viewModel.currentEndCompetition?.competitionName ?? ""
+        let primary = won ? Color.white : Color("Ink")
+        let accent = won ? Color.white.opacity(0.82) : Color("InkSoft")
+        return (
+            Text(name + "\n")
+                .foregroundColor(primary)
+            + Text(viewModel.headlineAccent)
+                .italic()
+                .foregroundColor(accent)
         )
+        .font(.system(size: 27, weight: .regular, design: .serif))
+        .tracking(-0.54)
+        .lineSpacing(1)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Body region (white)
+
+    private var bodyRegion: some View {
+        VStack(spacing: 18) {
+            CompetitionPodiumView(entries: viewModel.podiumEntries,
+                                  scoringUnit: viewModel.currentEndCompetition?.scoringUnit ?? .points)
+            CompetitionResultSummaryRow(placement: viewModel.userPlacement,
+                                        title: youFinishedTitle,
+                                        subline: viewModel.outcomeSubline,
+                                        score: viewModel.userScoreValue,
+                                        unitTag: viewModel.unitTagText)
+            actions
+        }
+        .padding(.top, 20)
+        .padding(.horizontal, 22)
+        .padding(.bottom, 24)
+        .frame(maxWidth: .infinity)
+        .background(
+            UnevenRoundedRectangle(topLeadingRadius: 20, topTrailingRadius: 20, style: .continuous)
+                .fill(Color("Surface"))
+        )
+    }
+
+    private var youFinishedTitle: String {
+        guard viewModel.userPlacement != nil else { return "Competition complete" }
+        return "You finished \(viewModel.userPositionOrdinal ?? "") of \(viewModel.memberCount)"
     }
 
     // MARK: - Actions
 
-    private var actionRow: some View {
-        VStack(spacing: 10) {
-            // Primary CTA — "Demand a rematch" or "Rematch" depending on variant.
-            FWFPrimaryButton(rematchCtaTitle) {
-                // Signal the parent to open the create wizard from the cover's
-                // onDismiss, then dismiss. Opening it here races the dismissal
-                // animation and SwiftUI silently drops the presentation.
+    private var actions: some View {
+        VStack(spacing: 9) {
+            // Rematch — restarts the same competition with the same people.
+            Button {
                 onRematch()
-                viewModel.dismissCurrent()
-                dismiss()
+                dismissSheet()
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 17, weight: .semibold))
+                    Text("Rematch")
+                        .font(.system(size: 16, weight: .semibold))
+                }
+                .foregroundStyle(Color("BgDeep"))
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+                .background(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(Color("Ink"))
+                )
             }
+            .buttonStyle(.plain)
             .accessibilityIdentifier("competitionEndRematchButton")
 
-            FWFSecondaryButton(shareCtaTitle, icon: "square.and.arrow.up") {
-                showingShare = true
+            HStack(spacing: 9) {
+                ghostButton(title: "Share", icon: "square.and.arrow.up", color: Color("Ink")) {
+                    presentShare()
+                }
+                .accessibilityIdentifier("competitionEndShareButton")
+
+                ghostButton(title: "Full standings", icon: "list.number", color: Color("Brand")) {
+                    if let competition = viewModel.currentEndCompetition {
+                        onViewStandings(competition)
+                    }
+                    dismissSheet()
+                }
+                .accessibilityIdentifier("competitionEndStandingsButton")
             }
         }
+        .padding(.top, 4)
     }
 
-    private var rematchCtaTitle: String {
-        switch viewModel.endVariant {
-        case .silver, .last: return "Demand a rematch"
-        default: return "Start a new competition"
+    private func ghostButton(title: String, icon: String, color: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 7) {
+                Image(systemName: icon)
+                    .font(.system(size: 14.5, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 14.5, weight: .semibold))
+            }
+            .foregroundStyle(color)
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color("Surface"))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .strokeBorder(Color("BorderStrong"), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Share
+
+    private func presentShare() {
+        var items: [Any] = []
+        if let image = renderShareCard() {
+            items.append(image)
+        }
+        items.append(viewModel.shareText)
+        if let url = URL(string: CompetitionEndAlertViewModel.appStoreURL) {
+            items.append(url)
+        }
+        shareItems = items
+        showingShare = true
+    }
+
+    private func renderShareCard() -> UIImage? {
+        let card = CompetitionShareCardView(
+            outcome: viewModel.endOutcome,
+            competitionName: viewModel.currentEndCompetition?.competitionName ?? "",
+            accent: viewModel.headlineAccent,
+            entries: viewModel.podiumEntries,
+            scoringUnit: viewModel.currentEndCompetition?.scoringUnit ?? .points,
+            placement: viewModel.userPlacement,
+            youFinishedTitle: youFinishedTitle,
+            subline: viewModel.outcomeSubline,
+            score: viewModel.userScoreValue,
+            unitTag: viewModel.unitTagText
+        )
+        // Force light mode so the shared card reads consistently regardless of device appearance.
+        let renderer = ImageRenderer(content: card.environment(\.colorScheme, .light))
+        renderer.scale = max(displayScale, 3)
+        return renderer.uiImage
+    }
+}
+
+// MARK: - Shared podium visualization (top-3 pedestals)
+
+/// The top-3 podium used by both the result sheet and the rendered share card. Stage order
+/// left → right is 2nd · 1st · 3rd (center-tallest). The current user's pedestal — when they're
+/// on the podium — gets the brand-gradient highlight.
+struct CompetitionPodiumView: View {
+    let entries: [CompetitionEndAlertViewModel.PodiumEntry]
+    let scoringUnit: ScoringUnit
+
+    var body: some View {
+        let byPosition = Dictionary(uniqueKeysWithValues: entries.map { ($0.position, $0) })
+        let staged = [byPosition[2], byPosition[1], byPosition[3]].compactMap { $0 }
+        return HStack(alignment: .bottom, spacing: 10) {
+            ForEach(staged) { entry in
+                column(entry)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func column(_ entry: CompetitionEndAlertViewModel.PodiumEntry) -> some View {
+        let isYou = entry.isCurrentUser
+        let medal = MedalPalette.color(for: entry.position)
+
+        return VStack(spacing: 0) {
+            FWFAvatar(name: isYou ? "You" : entry.displayName,
+                      size: entry.position == 1 ? 46 : 38,
+                      ring: medal)
+
+            Text(isYou ? "You" : entry.firstName)
+                .font(.system(size: 12, weight: isYou ? .bold : .semibold))
+                .foregroundStyle(Color("Ink"))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .padding(.top, 7)
+
+            Text(pointsText(entry.points))
+                .font(.system(size: 12.5, weight: .bold))
+                .monospacedDigit()
+                .foregroundStyle(Color("Ink"))
+                .padding(.top, 1)
+
+            pedestal(entry: entry, highlighted: isYou, medal: medal)
+                .padding(.top, 8)
+        }
+        .frame(width: 84)
+    }
+
+    @ViewBuilder
+    private func pedestal(entry: CompetitionEndAlertViewModel.PodiumEntry,
+                          highlighted: Bool,
+                          medal: Color?) -> some View {
+        let height: CGFloat = {
+            switch entry.position {
+            case 1: return 64
+            case 2: return 44
+            default: return 32
+            }
+        }()
+        let shape = UnevenRoundedRectangle(topLeadingRadius: 10, topTrailingRadius: 10, style: .continuous)
+        let numberColor: Color = highlighted ? .white : (medal ?? Color("InkMute"))
+
+        ZStack {
+            if highlighted {
+                shape.fill(LinearGradient(colors: [Color("Brand"), Color("BrandHi")],
+                                          startPoint: .top, endPoint: .bottom))
+            } else if entry.position == 1 {
+                // color-mix(gold 26%, surface-alt)
+                shape.fill(Color("SurfaceAlt"))
+                shape.fill(Color("Gold").opacity(0.26))
+            } else {
+                shape.fill(Color("SurfaceAlt"))
+                shape.strokeBorder(Color("Border"), lineWidth: 1)
+            }
+
+            Text("\(entry.position)")
+                .font(.system(size: 16, weight: .heavy))
+                .monospacedDigit()
+                .foregroundStyle(numberColor)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: height)
+    }
+
+    private func pointsText(_ points: Double?) -> String {
+        guard let points else { return "—" }
+        return ScoringValueFormatter.formatCompact(points, unit: scoringUnit)
+    }
+}
+
+// MARK: - Shared "You finished" summary row
+
+/// The brand-tinted "you" treatment summarizing the user's final placement, score, and the
+/// outcome subline. Shared by the result sheet and the rendered share card.
+struct CompetitionResultSummaryRow: View {
+    let placement: Int?
+    let title: String
+    let subline: String
+    let score: String
+    let unitTag: String
+
+    var body: some View {
+        let medal = MedalPalette.color(for: placement)
+        HStack(spacing: 11) {
+            ZStack {
+                if let medal {
+                    Circle().fill(medal)
+                } else {
+                    Circle().fill(Color("SurfaceAlt"))
+                    Circle().strokeBorder(Color("Border"), lineWidth: 1)
+                }
+                if let placement {
+                    Text("\(placement)")
+                        .font(.system(size: 13, weight: .bold))
+                        .monospacedDigit()
+                        .foregroundStyle(medal != nil ? .white : Color("InkSoft"))
+                }
+            }
+            .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.system(size: 14.5, weight: .bold))
+                    .foregroundStyle(Color("Ink"))
+                Text(subline)
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color("InkSoft"))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 0) {
+                Text(score)
+                    .font(.system(size: 19, weight: .heavy))
+                    .monospacedDigit()
+                    .foregroundStyle(Color("Brand"))
+                Text(unitTag)
+                    .font(.system(size: 9, weight: .semibold))
+                    .tracking(0.9)
+                    .foregroundStyle(Color("InkMute"))
+            }
+        }
+        .padding(.horizontal, 13)
+        .padding(.vertical, 11)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color("BrandSoft"))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(Color("Brand"), lineWidth: 1.5)
+        )
+    }
+}
+
+// MARK: - Share card (rendered to an image)
+
+/// A self-contained, fixed-size result card rasterized by `ImageRenderer` for the system share
+/// sheet. Mirrors the sheet's visual language (brand-gradient cap on a win, podium, "you finished"
+/// row) plus a wordmark footer, sized for social/message sharing.
+struct CompetitionShareCardView: View {
+    let outcome: CompetitionEndAlertViewModel.EndOutcome
+    let competitionName: String
+    let accent: String
+    let entries: [CompetitionEndAlertViewModel.PodiumEntry]
+    let scoringUnit: ScoringUnit
+    let placement: Int?
+    let youFinishedTitle: String
+    let subline: String
+    let score: String
+    let unitTag: String
+
+    private var won: Bool { outcome == .won }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            VStack(spacing: 16) {
+                CompetitionPodiumView(entries: entries, scoringUnit: scoringUnit)
+                CompetitionResultSummaryRow(placement: placement,
+                                            title: youFinishedTitle,
+                                            subline: subline,
+                                            score: score,
+                                            unitTag: unitTag)
+                Spacer(minLength: 0)
+                footer
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .background(Color("Surface"))
+        }
+        .frame(width: 340, height: 460)
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 7) {
+                if won {
+                    Image(systemName: "trophy.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+                Text("Final results")
+                    .font(.system(size: 10.5, weight: .semibold))
+                    .tracking(1.05)
+                    .textCase(.uppercase)
+                    .foregroundStyle(won ? Color.white.opacity(0.82) : Color("InkSoft"))
+            }
+
+            (
+                Text(competitionName + "\n")
+                    .foregroundColor(won ? .white : Color("Ink"))
+                + Text(accent)
+                    .italic()
+                    .foregroundColor(won ? Color.white.opacity(0.82) : Color("InkSoft"))
+            )
+            .font(.system(size: 24, weight: .regular, design: .serif))
+            .tracking(-0.48)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(headerBackground)
+    }
+
+    @ViewBuilder
+    private var headerBackground: some View {
+        if won {
+            LinearGradient(colors: [Color("BrandHi"), Color("Brand")],
+                           startPoint: .topLeading,
+                           endPoint: .bottomTrailing)
+        } else {
+            Color("SurfaceAlt")
         }
     }
 
-    private var shareCtaTitle: String {
-        switch viewModel.endVariant {
-        case .won:    return "Share win"
-        case .midPack: return "Share streak"
-        case .last:   return "Share progress"
-        default:      return "Share"
+    private var footer: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "figure.run.circle.fill")
+                .font(.system(size: 16))
+                .foregroundStyle(Color("Brand"))
+            Text("Fit with Friends")
+                .font(.system(size: 14, weight: .regular, design: .serif))
+                .foregroundStyle(Color("InkMute"))
         }
-    }
-
-    private var shareText: String? {
-        guard let competition = viewModel.currentEndCompetition,
-              let ordinal = viewModel.userPositionOrdinal else { return nil }
-        return "I finished \(ordinal) in \(competition.competitionName) on FitWithFriends."
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Custom Views/ShareSheet.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Custom Views/ShareSheet.swift
@@ -9,15 +9,26 @@ import Foundation
 import SwiftUI
 import UIKit
 
-/// A wrapper around UIActivityViewController
-/// Used for sharing a URL to external apps
+/// A wrapper around UIActivityViewController.
+/// Used for sharing content (URLs, plain text, rendered images) to external apps. Each
+/// share target picks the activity items it understands, so a single share can offer an
+/// image to Photos/Messages and a URL+text to Mail, etc.
 struct ShareSheet: UIViewControllerRepresentable {
     typealias UIViewControllerType = UIActivityViewController
 
-    let url: URL
+    let activityItems: [Any]
+
+    init(activityItems: [Any]) {
+        self.activityItems = activityItems
+    }
+
+    /// Convenience for the common "share a single URL" callers.
+    init(url: URL) {
+        self.activityItems = [url]
+    }
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
-        return UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        return UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
     }
 
     func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}

--- a/Clients/iOS/FitWithFriends/FitWithFriends/Views/Home/LoggedInContentView.swift
+++ b/Clients/iOS/FitWithFriends/FitWithFriends/Views/Home/LoggedInContentView.swift
@@ -27,6 +27,11 @@ struct LoggedInContentView: View {
     // in the detail sheet's onDismiss.
     @State private var shouldShowCreateAfterDetail = false
 
+    // Set when the user taps "Full standings" on the competition-end sheet; the captured
+    // competition is opened in the detail sheet from the end sheet's onDismiss (presenting
+    // it while the sheet animates out gets dropped by SwiftUI).
+    @State private var standingsCompetitionAfterEnd: CompetitionOverview?
+
     init(objectGraph: IObjectGraph) {
         self.objectGraph = objectGraph
         _homepageSheetViewModel = StateObject(wrappedValue: HomepageSheetViewModel(appProtocolHandler: objectGraph.appProtocolHandler,
@@ -202,23 +207,29 @@ struct LoggedInContentView: View {
                 ConfettiOverlayView()
             }
         }
-        .fullScreenCover(
+        .sheet(
             isPresented: Binding(
                 get: { competitionEndAlertViewModel.currentEndCompetition != nil },
                 set: { if !$0 { competitionEndAlertViewModel.dismissCurrent() } }
             ),
             onDismiss: {
-                // Open the create wizard only once the end cover has fully dismissed —
-                // presenting it while the cover animates out gets dropped by SwiftUI.
+                // Open the follow-on sheet only once the end sheet has fully dismissed —
+                // presenting it while the sheet animates out gets dropped by SwiftUI.
                 if shouldShowCreateAfterEnd {
                     shouldShowCreateAfterEnd = false
                     homepageSheetViewModel.updateState(sheet: .createCompetition, state: true)
+                } else if let competition = standingsCompetitionAfterEnd {
+                    standingsCompetitionAfterEnd = nil
+                    homepageSheetViewModel.updateState(sheet: .competitionDetails,
+                                                       state: true,
+                                                       contextData: competition)
                 }
             }
         ) {
             CompetitionEndView(
                 viewModel: competitionEndAlertViewModel,
-                onRematch: { shouldShowCreateAfterEnd = true }
+                onRematch: { shouldShowCreateAfterEnd = true },
+                onViewStandings: { competition in standingsCompetitionAfterEnd = competition }
             )
         }
     }

--- a/Clients/iOS/FitWithFriends/UnitTests/CompetitionEndAlertViewModelTests.swift
+++ b/Clients/iOS/FitWithFriends/UnitTests/CompetitionEndAlertViewModelTests.swift
@@ -4,6 +4,7 @@
 //
 
 import Combine
+import SwiftUI
 import XCTest
 @testable import Fit_with_Friends
 
@@ -170,14 +171,26 @@ final class CompetitionEndAlertViewModelTests: XCTestCase {
         XCTAssertTrue(vm.shouldShowConfetti)
     }
 
-    func test_userInThirdPlace_showsConfetti() async {
+    func test_userInThirdPlace_noConfetti() async {
+        // The podium sheet celebrates a win only — confetti no longer fires for podium
+        // finishes (2nd/3rd), only for 1st.
         let vm = makeVM()
         let competition = makeArchivedCompetition(userPosition: 3)
 
         mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
-        await waitUntil(vm.shouldShowConfetti)
+        await waitUntil(vm.currentAlertCompetition != nil)
 
-        XCTAssertTrue(vm.shouldShowConfetti)
+        XCTAssertFalse(vm.shouldShowConfetti)
+    }
+
+    func test_userInSecondPlace_noConfetti() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 2)
+
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        XCTAssertFalse(vm.shouldShowConfetti)
     }
 
     func test_userInFourthPlace_noConfetti() async {
@@ -556,5 +569,207 @@ final class CompetitionEndAlertViewModelTests: XCTestCase {
 
         // Current alert should not have changed
         XCTAssertEqual(vm.currentAlertCompetition?.competitionId, firstCompetitionId)
+    }
+
+    // MARK: - Podium sheet (Direction B) presentation model
+
+    func test_endOutcome_firstPlace_won() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 1, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        XCTAssertEqual(vm.endOutcome, .won)
+    }
+
+    func test_endOutcome_midPack_mid() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 2, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        // 2nd of 6 is neither first nor last → mid.
+        XCTAssertEqual(vm.endOutcome, .mid)
+    }
+
+    func test_endOutcome_lastPlace_last() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 6, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        XCTAssertEqual(vm.endOutcome, .last)
+    }
+
+    func test_userPlacementAndMemberCount() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 4, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        XCTAssertEqual(vm.userPlacement, 4)
+        XCTAssertEqual(vm.memberCount, 6)
+    }
+
+    func test_isUserOnPodium_trueForTopThree() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 3, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        XCTAssertTrue(vm.isUserOnPodium)
+    }
+
+    func test_isUserOnPodium_falseForMidPack() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 4, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        XCTAssertFalse(vm.isUserOnPodium)
+    }
+
+    func test_headlineAccent_perOutcome() async {
+        let vm = makeVM()
+
+        let won = makeArchivedCompetition(id: UUID(), name: "A", userPosition: 1, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [won.competitionId: won]
+        await waitUntil(vm.currentAlertCompetition != nil)
+        XCTAssertEqual(vm.headlineAccent, "You won.")
+        vm.dismissCurrent()
+
+        let mid = makeArchivedCompetition(id: UUID(), name: "B", userPosition: 3, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [mid.competitionId: mid]
+        await waitUntil(vm.currentAlertCompetition != nil)
+        XCTAssertEqual(vm.headlineAccent, "Strong showing.")
+        vm.dismissCurrent()
+
+        let last = makeArchivedCompetition(id: UUID(), name: "C", userPosition: 6, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [last.competitionId: last]
+        await waitUntil(vm.currentAlertCompetition != nil)
+        XCTAssertEqual(vm.headlineAccent, "Every day counts.")
+    }
+
+    func test_outcomeSubline_lastIncludesDayCount() async {
+        let vm = makeVM()
+        // Competition spans 7 days (start -8d, end -1d).
+        let competition = makeArchivedCompetition(userPosition: 6, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        XCTAssertTrue(vm.outcomeSubline.contains("7 days"), "Expected day count in '\(vm.outcomeSubline)'")
+        XCTAssertTrue(vm.outcomeSubline.contains("never quit"))
+    }
+
+    func test_podiumEntries_returnsTopThreeInOrder() async {
+        let vm = makeVM()
+        // User is 4th, so they should NOT appear in the podium (top 3 only).
+        let competition = makeArchivedCompetition(userPosition: 4, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        let podium = vm.podiumEntries
+        XCTAssertEqual(podium.count, 3)
+        XCTAssertEqual(podium.map { $0.position }, [1, 2, 3])
+        // Descending points: (6-0)*100=600, 500, 400.
+        XCTAssertEqual(podium.map { $0.points }, [600, 500, 400])
+        XCTAssertFalse(podium.contains { $0.isCurrentUser })
+    }
+
+    func test_podiumEntries_flagsCurrentUserWhenOnPodium() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 1, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        let podium = vm.podiumEntries
+        XCTAssertEqual(podium.first(where: { $0.isCurrentUser })?.position, 1)
+    }
+
+    func test_userScoreValue_formatsPointsWithoutSuffix() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 2, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        // Position 2 of 6 → (6-1)*100 = 500, no unit suffix.
+        XCTAssertEqual(vm.userScoreValue, "500")
+    }
+
+    func test_unitTagText_defaultsToPTS() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(userPosition: 1, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        XCTAssertEqual(vm.unitTagText, "PTS")
+    }
+
+    // MARK: - Share
+
+    func test_shareText_win_includesTrophyAndPlacement() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(name: "Step Showdown", userPosition: 1, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        let text = vm.shareText
+        XCTAssertTrue(text.contains("🏆"), "Expected trophy in '\(text)'")
+        XCTAssertTrue(text.contains("1st of 6"))
+        XCTAssertTrue(text.contains("Step Showdown"))
+        XCTAssertTrue(text.contains("Fit with Friends"))
+    }
+
+    func test_shareText_midPack_noTrophy() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(name: "Step Showdown", userPosition: 3, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        let text = vm.shareText
+        XCTAssertFalse(text.contains("🏆"))
+        XCTAssertTrue(text.contains("3rd of 6"))
+    }
+
+    func test_shareText_last_includesDayCount() async {
+        let vm = makeVM()
+        let competition = makeArchivedCompetition(name: "Step Showdown", userPosition: 6, totalUsers: 6)
+        mockCompetitionManager.return_competitionOverviews = [competition.competitionId: competition]
+        await waitUntil(vm.currentAlertCompetition != nil)
+
+        let text = vm.shareText
+        XCTAssertTrue(text.contains("7 days"), "Expected day count in '\(text)'")
+        XCTAssertTrue(text.contains("never quit"))
+    }
+
+    func test_appStoreURL_isValid() {
+        XCTAssertNotNil(URL(string: CompetitionEndAlertViewModel.appStoreURL))
+        XCTAssertTrue(CompetitionEndAlertViewModel.appStoreURL.contains("apps.apple.com"))
+    }
+
+    func test_shareCard_rendersNonNilImage() {
+        // Smoke test: the share card builds and rasterizes via ImageRenderer for each outcome.
+        let entries = [
+            CompetitionEndAlertViewModel.PodiumEntry(position: 1, firstName: "You", displayName: "You", points: 612, isCurrentUser: true),
+            CompetitionEndAlertViewModel.PodiumEntry(position: 2, firstName: "Alice", displayName: "Alice Chen", points: 580, isCurrentUser: false),
+            CompetitionEndAlertViewModel.PodiumEntry(position: 3, firstName: "Marcus", displayName: "Marcus Lee", points: 512, isCurrentUser: false),
+        ]
+        for outcome in [CompetitionEndAlertViewModel.EndOutcome.won, .mid, .last] {
+            let card = CompetitionShareCardView(
+                outcome: outcome,
+                competitionName: "Saturday Step Showdown",
+                accent: "You won.",
+                entries: entries,
+                scoringUnit: .points,
+                placement: 1,
+                youFinishedTitle: "You finished 1st of 6",
+                subline: "First place is yours.",
+                score: "612",
+                unitTag: "PTS"
+            )
+            let renderer = ImageRenderer(content: card.environment(\.colorScheme, .light))
+            renderer.scale = 3
+            XCTAssertNotNil(renderer.uiImage, "Share card failed to render for outcome \(outcome)")
+        }
     }
 }


### PR DESCRIPTION
## Overview

Replaces the full-screen competition-end screen with the **"Podium" results sheet** (design Direction B), presented as a bottom sheet over the home feed. The old screen failed to (a) name the competition that finished and (b) show where the user landed — the new sheet does both, and adapts its tone across three outcomes (loud on a win, gracious on a mid/last finish).

It also **fixes the broken "Share result" button**, which previously shared `https://example.com` because `ShareSheet` only accepted a URL and the result sentence (with spaces) failed `URL(string:)`.

## What changed

**The sheet** ([CompetitionEndView.swift](../blob/claude/elegant-khayyam-4cdbe9/Clients/iOS/FitWithFriends/FitWithFriends/Views/Competitions/CompetitionEndView.swift))
- Brand-gradient header cap + confetti on a win (win-only); flat `SurfaceAlt` cap otherwise.
- Serif headline = competition name + outcome-tuned italic accent ("You won." / "Strong showing." / "Every day counts.").
- Top-3 **podium** (2-1-3 stage order, medal-ring avatars, center-tallest pedestals, your pedestal highlighted) and a brand-tinted **"You finished Nth of N"** row.
- Actions: **Rematch**, **Share**, **Full standings** (routes to the existing Competition Detail screen).
- Extracted `CompetitionPodiumView` and `CompetitionResultSummaryRow` so the sheet and the share card share one implementation.

**Share** ([ShareSheet.swift](../blob/claude/elegant-khayyam-4cdbe9/Clients/iOS/FitWithFriends/FitWithFriends/Views/Custom%20Views/ShareSheet.swift), CompetitionEndView, [CompetitionEndAlertViewModel.swift](../blob/claude/elegant-khayyam-4cdbe9/Clients/iOS/FitWithFriends/FitWithFriends/ViewModels/Home/CompetitionEndAlertViewModel.swift))
- `ShareSheet` now takes `[Any]` activity items (kept the `init(url:)` convenience so the 3 existing callers are untouched).
- Share renders a standalone `CompetitionShareCardView` to an image via `ImageRenderer` (forced light mode, scale 3) and offers `[image, hype text, App Store link]` — the card brags, the link converts.

**Presentation** ([LoggedInContentView.swift](../blob/claude/elegant-khayyam-4cdbe9/Clients/iOS/FitWithFriends/FitWithFriends/Views/Home/LoggedInContentView.swift))
- `fullScreenCover` → `.sheet` with `presentationDetents`/`presentationCornerRadius(30)`, plus a "Full standings" handoff to the detail sheet.

## Notable decisions
- **Confetti is now win-only** to match the design (previously top-3). Confetti fires inside the sheet's cap and is `reduceMotion`-aware.
- The richer recap stats on the old screen (streaks, best day, etc.) are intentionally not shown on the Podium direction; those computeds remain in the view model for other directions.
- New view types live inside `CompetitionEndView.swift` (the project doesn't use synchronized file groups, so this avoids fragile `.pbxproj` edits).

## Testing
- App builds clean.
- **54/54 unit tests pass** — added 13 (`endOutcome`, podium entries, placement/member count, share text per outcome, App Store URL, and a card-render smoke test across all outcomes); updated confetti expectations for win-only.
- **5/5 `CompetitionEndedAlertTests` UI tests pass** (dismiss-via-grab-handle and rematch flows).
- Visually verified the win and non-win sheet states and the rendered share card in the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)